### PR TITLE
Improve session parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,13 @@ so, _ := gosn.Sync(gosn.SyncInput{
 items, _ := so.Items.DecryptAndParse(&sio.Session)
 ```
 
+## running tests
+
+Execute the full test suite using the standard Go tooling:
+
+```bash
+go test ./...
+```
+
+This runs all unit tests across the repository.
+

--- a/session/parse_test.go
+++ b/session/parse_test.go
@@ -1,0 +1,22 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSessionStringValid(t *testing.T) {
+	sessionString := "{\"Server\":\"http://ramea:3000\",\"Token\":\"\",\"MasterKey\":\"5319f9c148ee3dbe78fc149e8643775242d7e83216060ee5e228ab2ec3d88a76\",\"keyParams\":{\"created\":\"1608473387799\",\"identifier\":\"test-user\",\"origination\":\"registration\",\"pw_nonce\":\"yJTyMmLr3KqOc7ifRfe1H7Pu8591n7Sj\",\"version\":\"004\"},\"access_token\":\"1:3dc699a1-451d-4de3-b01d-fca32554292b:Io9MOsc.WDIq0JBt\",\"refresh_token\":\"1:3dc699a1-451d-4de3-b01d-fca32554292b:-ixQV.-RMCCSPG0M\",\"access_expiration\":1648647400000,\"refresh_expiration\":1675020326000,\"SchemaValidation\":false}"
+
+	sess, err := ParseSessionString(sessionString)
+	require.NoError(t, err)
+	require.Equal(t, "http://ramea:3000", sess.Server)
+	require.Equal(t, "5319f9c148ee3dbe78fc149e8643775242d7e83216060ee5e228ab2ec3d88a76", sess.MasterKey)
+	require.Equal(t, int64(1648647400000), sess.AccessExpiration)
+}
+
+func TestParseSessionStringInvalid(t *testing.T) {
+	_, err := ParseSessionString("not-json")
+	require.Error(t, err)
+}

--- a/session/session.go
+++ b/session/session.go
@@ -537,21 +537,23 @@ func GetSession(httpClient *retryablehttp.Client, loadSession bool, sessionKey, 
 	return session, email, nil
 }
 
-func ParseSessionString(ss string) (sess Session, err error) {
+func ParseSessionString(ss string) (Session, error) {
 	var ms MinimalSession
-	err = json.Unmarshal([]byte(ss), &ms)
 
-	sess.Server = ms.Server
-	sess.AccessToken = ms.AccessToken
-	sess.AccessExpiration = ms.AccessExpiration
-	sess.RefreshToken = ms.RefreshToken
-	sess.RefreshExpiration = ms.RefreshExpiration
-	sess.MasterKey = ms.MasterKey
-	sess.Server = ms.Server
-	sess.KeyParams = ms.KeyParams
-	sess.PasswordNonce = ms.KeyParams.PwNonce
+	if err := json.Unmarshal([]byte(ss), &ms); err != nil {
+		return Session{}, err
+	}
 
-	return
+	return Session{
+		Server:            ms.Server,
+		AccessToken:       ms.AccessToken,
+		AccessExpiration:  ms.AccessExpiration,
+		RefreshToken:      ms.RefreshToken,
+		RefreshExpiration: ms.RefreshExpiration,
+		MasterKey:         ms.MasterKey,
+		KeyParams:         ms.KeyParams,
+		PasswordNonce:     ms.KeyParams.PwNonce,
+	}, nil
 }
 
 func isUnencryptedSession(in string) bool {


### PR DESCRIPTION
## Summary
- add instructions for running tests in README
- clean up ParseSessionString logic
- add unit tests for ParseSessionString

## Testing
- `go test ./...` *(fails: no route to host)*