### PR TITLE
Simplify slice utilities

### DIFF
--- a/items/items.go
+++ b/items/items.go
@@ -529,14 +529,8 @@ type TagContent struct {
 	AppData        AppDataContent `json:"appData"`
 }
 
-func removeStringFromSlice(inSt string, inSl []string) (outSl []string) {
-	for _, si := range inSl {
-		if inSt != si {
-			outSl = append(outSl, si)
-		}
-	}
-
-	return
+func removeStringFromSlice(inSt string, inSl []string) []string {
+	return slices.DeleteFunc(inSl, func(s string) bool { return s == inSt })
 }
 
 type ItemReferences []ItemReference
@@ -877,16 +871,14 @@ func (ei *EncryptedItems) RemoveDeleted() {
 }
 
 func (i *Items) DeDupe() {
-	var encountered []string
-
-	var deDuped Items
+	encountered := make(map[string]struct{})
+	deDuped := make(Items, 0, len(*i))
 
 	for _, j := range *i {
-		if !slices.Contains(encountered, j.GetUUID()) {
+		if _, ok := encountered[j.GetUUID()]; !ok {
+			encountered[j.GetUUID()] = struct{}{}
 			deDuped = append(deDuped, j)
 		}
-
-		encountered = append(encountered, j.GetUUID())
 	}
 
 	*i = deDuped

--- a/items/utility_test.go
+++ b/items/utility_test.go
@@ -1,0 +1,59 @@
+package items
+
+import (
+	"testing"
+
+	"slices"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubItem struct{ uuid string }
+
+func (s *stubItem) GetItemsKeyID() string        { return "" }
+func (s *stubItem) GetUUID() string              { return s.uuid }
+func (s *stubItem) SetUUID(u string)             { s.uuid = u }
+func (s *stubItem) GetContentSize() int          { return 0 }
+func (s *stubItem) SetContentSize(int)           {}
+func (s *stubItem) GetContentType() string       { return "" }
+func (s *stubItem) SetContentType(string)        {}
+func (s *stubItem) IsDeleted() bool              { return false }
+func (s *stubItem) SetDeleted(bool)              {}
+func (s *stubItem) GetCreatedAt() string         { return "" }
+func (s *stubItem) SetCreatedAt(string)          {}
+func (s *stubItem) SetUpdatedAt(string)          {}
+func (s *stubItem) GetUpdatedAt() string         { return "" }
+func (s *stubItem) GetCreatedAtTimestamp() int64 { return 0 }
+func (s *stubItem) SetCreatedAtTimestamp(int64)  {}
+func (s *stubItem) SetUpdatedAtTimestamp(int64)  {}
+func (s *stubItem) GetUpdatedAtTimestamp() int64 { return 0 }
+func (s *stubItem) GetContent() Content          { return nil }
+func (s *stubItem) SetContent(Content)           {}
+func (s *stubItem) IsDefault() bool              { return false }
+func (s *stubItem) GetDuplicateOf() string       { return "" }
+
+func TestRemoveStringFromSlice(t *testing.T) {
+	in := []string{"a", "b", "c", "b"}
+	out := removeStringFromSlice("b", in)
+	require.Equal(t, []string{"a", "c"}, out)
+}
+
+func TestRemoveStringFromSliceMissing(t *testing.T) {
+	in := []string{"a", "b"}
+	out := removeStringFromSlice("x", in)
+	require.Equal(t, in, out)
+}
+
+func TestItemsDeDupe(t *testing.T) {
+	items := Items{
+		&stubItem{uuid: "a"},
+		&stubItem{uuid: "b"},
+		&stubItem{uuid: "a"},
+		&stubItem{uuid: "b"},
+	}
+	items.DeDupe()
+	require.Len(t, items, 2)
+	uuids := []string{items[0].GetUUID(), items[1].GetUUID()}
+	slices.Sort(uuids)
+	require.Equal(t, []string{"a", "b"}, uuids)
+}


### PR DESCRIPTION
## Summary
- simplify `removeStringFromSlice` using `slices.DeleteFunc`
- optimize `Items.DeDupe` using a map
- test new helpers

## Testing
- `go test ./... 2>&1 | head -n 20` *(fails: MockKeyRingDodgy does not implement keyring.Keyring)*