### PR TITLE
Refactor auth response parsing

### DIFF
--- a/auth/auth_unmarshal_test.go
+++ b/auth/auth_unmarshal_test.go
@@ -1,0 +1,30 @@
+package auth_test
+
+import (
+	"net/http"
+	"testing"
+
+	auth "github.com/jonhadfield/gosn-v2/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalAuthRequestResponseOK(t *testing.T) {
+	body := []byte(`{"data":{"identifier":"id","pw_salt":"salt","pw_cost":1,"pw_nonce":"nonce","version":"004"}}`)
+	out, errResp, err := auth.UnmarshalAuthRequestResponseForTest(http.StatusOK, body, false)
+	require.NoError(t, err)
+	require.Equal(t, "id", out.Data.Identifier)
+	require.Empty(t, errResp.Data.Error.Message)
+}
+
+func TestUnmarshalAuthRequestResponseNotFound(t *testing.T) {
+	body := []byte(`{"meta":{},"data":{"error":{"tag":"invalid","message":"not found","payload":{"mfa_key":"abc"}}}}`)
+	out, errResp, err := auth.UnmarshalAuthRequestResponseForTest(http.StatusNotFound, body, false)
+	require.NoError(t, err)
+	require.Equal(t, "abc", errResp.Data.Error.Payload.MFAKey)
+	require.Empty(t, out.Data.Identifier)
+}
+
+func TestUnmarshalAuthRequestResponseForbidden(t *testing.T) {
+	_, _, err := auth.UnmarshalAuthRequestResponseForTest(http.StatusForbidden, []byte(`{}`), false)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- split auth response parsing into its own function
- expose helper for tests
- add unit tests for auth response unmarshalling

## Testing
- `go test ./auth -run UnmarshalAuthRequestResponse -count=1` *(fails: cannot connect to remote host)*