### PR TITLE
Define constants for env vars

### DIFF
--- a/auth/authentication_test.go
+++ b/auth/authentication_test.go
@@ -22,9 +22,9 @@ var (
 	testUserEmail    string
 	testUserPassword string
 	sInput           = SignInInput{
-		Email:     os.Getenv("SN_EMAIL"),
-		Password:  os.Getenv("SN_PASSWORD"),
-		APIServer: os.Getenv("SN_SERVER"),
+		Email:     os.Getenv(common.EnvEmail),
+		Password:  os.Getenv(common.EnvPassword),
+		APIServer: os.Getenv(common.EnvServer),
 		Debug:     true,
 	}
 )
@@ -59,19 +59,19 @@ func localTestMain() {
 }
 
 func TestMain(m *testing.M) {
-	if os.Getenv("SN_SERVER") == "" || strings.Contains(os.Getenv("SN_SERVER"), "ramea") {
+	if os.Getenv(common.EnvServer) == "" || strings.Contains(os.Getenv(common.EnvServer), "ramea") {
 		localTestMain()
 	} else {
 		httpClient := common.NewHTTPClient()
 		out, err := SignIn(SignInInput{
 			HTTPClient: httpClient,
-			Email:      os.Getenv("SN_EMAIL"),
-			Password:   os.Getenv("SN_PASSWORD"),
-			APIServer:  os.Getenv("SN_SERVER"),
+			Email:      os.Getenv(common.EnvEmail),
+			Password:   os.Getenv(common.EnvPassword),
+			APIServer:  os.Getenv(common.EnvServer),
 			Debug:      true,
 		})
 		if err != nil {
-			panic(fmt.Sprintf("failed to sign-in with: %s", os.Getenv("SN_SERVER")))
+			panic(fmt.Sprintf("failed to sign-in with: %s", os.Getenv(common.EnvServer)))
 		}
 
 		testSession = &SignInResponseDataSession{
@@ -91,7 +91,7 @@ func TestMain(m *testing.M) {
 			PasswordNonce:     "",
 		}
 
-		if strings.ToLower(os.Getenv("SN_DEBUG")) == "true" {
+		if strings.ToLower(os.Getenv(common.EnvDebug)) == "true" {
 			testSession.Debug = true
 		}
 
@@ -125,7 +125,7 @@ func TestSignIn(t *testing.T) {
 	testSession = &sOut.Session
 
 	if testSession.AccessToken == "" || testSession.RefreshToken == "" || testSession.RefreshExpiration == 0 || testSession.AccessExpiration == 0 {
-		t.Errorf("SignIn Failed with %s", os.Getenv("SN_SERVER"))
+		t.Errorf("SignIn Failed with %s", os.Getenv(common.EnvServer))
 	}
 }
 
@@ -141,7 +141,7 @@ func TestRefreshSession(t *testing.T) {
 	// wait for 2 seconds to ensure that the expiration times are different
 	time.Sleep(1 * time.Second)
 
-	rt, err := RequestRefreshToken(so.Session.HTTPClient, os.Getenv("SN_SERVER")+common.AuthRefreshPath, so.Session.AccessToken, so.Session.RefreshToken, true)
+	rt, err := RequestRefreshToken(so.Session.HTTPClient, os.Getenv(common.EnvServer)+common.AuthRefreshPath, so.Session.AccessToken, so.Session.RefreshToken, true)
 	require.NoError(t, err)
 	require.NotEmpty(t, rt.Data.Session.AccessToken)
 	require.NotEmpty(t, rt.Data.Session.RefreshToken)
@@ -160,7 +160,7 @@ func TestRegistrationWithInvalidShortPassword(t *testing.T) {
 	rInput := RegisterInput{
 		Email:     testEmailAddr,
 		Password:  password,
-		APIServer: os.Getenv("SN_SERVER"),
+		APIServer: os.Getenv(common.EnvServer),
 	}
 	_, err := rInput.Register()
 	require.Error(t, err)
@@ -168,7 +168,7 @@ func TestRegistrationWithInvalidShortPassword(t *testing.T) {
 }
 
 func TestRegistrationAndSignInWithNewCredentials(t *testing.T) {
-	if strings.Contains(os.Getenv("SN_SERVER"), "ramea") {
+	if strings.Contains(os.Getenv(common.EnvServer), "ramea") {
 		emailAddr := testEmailAddr
 		password := "secretsanta"
 
@@ -176,7 +176,7 @@ func TestRegistrationAndSignInWithNewCredentials(t *testing.T) {
 			Password:  password,
 			Email:     emailAddr,
 			Version:   common.DefaultSNVersion,
-			APIServer: os.Getenv("SN_SERVER"),
+			APIServer: os.Getenv(common.EnvServer),
 			Debug:     true,
 		}
 
@@ -184,7 +184,7 @@ func TestRegistrationAndSignInWithNewCredentials(t *testing.T) {
 		require.NoError(t, err, "registration failed")
 
 		postRegSignInInput := SignInInput{
-			APIServer: os.Getenv("SN_SERVER"),
+			APIServer: os.Getenv(common.EnvServer),
 			Email:     emailAddr,
 			Password:  password,
 		}
@@ -201,12 +201,12 @@ func TestRegistrationAndSignInWithNewCredentials(t *testing.T) {
 }
 
 func TestRegistrationWithPreRegisteredEmail(t *testing.T) {
-	if strings.Contains(os.Getenv("SN_SERVER"), "ramea") {
+	if strings.Contains(os.Getenv(common.EnvServer), "ramea") {
 		password := "secret"
 		rInput := RegisterInput{
 			Email:     testEmailAddr,
 			Password:  password,
-			APIServer: os.Getenv("SN_SERVER"),
+			APIServer: os.Getenv(common.EnvServer),
 		}
 		_, err := rInput.Register()
 		require.Error(t, err, "email is already registered")
@@ -214,11 +214,11 @@ func TestRegistrationWithPreRegisteredEmail(t *testing.T) {
 }
 
 func TestRegistrationAndSignInWithEmailWithPlusSign(t *testing.T) {
-	if strings.Contains(os.Getenv("SN_SERVER"), "ramea") {
+	if strings.Contains(os.Getenv(common.EnvServer), "ramea") {
 		_, err := SignIn(SignInInput{
 			Email:     testEmailAddrWithPlus,
 			Password:  "secret",
-			APIServer: os.Getenv("SN_SERVER"),
+			APIServer: os.Getenv(common.EnvServer),
 			Debug:     true,
 		})
 		require.Error(t, err)
@@ -320,7 +320,7 @@ func TestSignInWithInvalidURL(t *testing.T) {
 func TestSignInWithUnavailableServer(t *testing.T) {
 	t.Parallel()
 
-	if os.Getenv("SN_SERVER") == "http://ramea:3000" {
+	if os.Getenv(common.EnvServer) == "http://ramea:3000" {
 		return
 	}
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -21,7 +21,7 @@ import (
 var testSession *Session
 
 func testSetup() {
-	gs, err := auth.CliSignIn(os.Getenv("SN_EMAIL"), os.Getenv("SN_PASSWORD"), os.Getenv("SN_SERVER"), true)
+	gs, err := auth.CliSignIn(os.Getenv(common.EnvEmail), os.Getenv(common.EnvPassword), os.Getenv(common.EnvServer), true)
 	if err != nil {
 		panic(err)
 	}
@@ -918,9 +918,9 @@ func cleanup(session *session.Session) {
 
 var (
 	sInput = auth.SignInInput{
-		Email:     os.Getenv("SN_EMAIL"),
-		Password:  os.Getenv("SN_PASSWORD"),
-		APIServer: os.Getenv("SN_SERVER"),
+		Email:     os.Getenv(common.EnvEmail),
+		Password:  os.Getenv(common.EnvPassword),
+		APIServer: os.Getenv(common.EnvServer),
 		Debug:     true,
 	}
 	testParas = []string{

--- a/common/env.go
+++ b/common/env.go
@@ -10,6 +10,11 @@ const (
 	EnvPostSyncRequestDelay = "SN_POST_SYNC_REQUEST_DELAY"
 	EnvPostSignInDelay      = "SN_POST_SIGN_IN_DELAY"
 	EnvSchemaValidation     = "SN_SCHEMA_VALIDATION"
+	EnvServer               = "SN_SERVER"
+	EnvEmail                = "SN_EMAIL"
+	EnvPassword             = "SN_PASSWORD"
+	EnvSkipSessionTests     = "SN_SKIP_SESSION_TESTS"
+	EnvDebug                = "SN_DEBUG"
 )
 
 // ParseEnvInt64 looks up an environment variable and attempts to parse

--- a/items/advancedChecklist.go
+++ b/items/advancedChecklist.go
@@ -10,6 +10,10 @@ import (
 
 const (
 	AdvancedChecklistNoteType = "com.sncommunity.advanced-checklist"
+	openTasksSectionID        = "open-tasks"
+	openTasksSectionName      = "Open"
+	completedTasksSectionID   = "completed-tasks"
+	completedTasksSectionName = "Completed"
 )
 
 type AdvancedChecklistTasks []AdvancedChecklistTask
@@ -115,13 +119,13 @@ func (c *AdvancedChecklist) AddTask(groupName, taskTitle string) error {
 			LastActive: time.Now(),
 			Sections: []AdvancedChecklistSection{
 				{
-					Id:        "open-tasks",
-					Name:      "Open",
+					Id:        openTasksSectionID,
+					Name:      openTasksSectionName,
 					Collapsed: false,
 				},
 				{
-					Id:        "completed-tasks",
-					Name:      "Completed",
+					Id:        completedTasksSectionID,
+					Name:      completedTasksSectionName,
 					Collapsed: false,
 				},
 			},
@@ -303,13 +307,13 @@ func (c *AdvancedChecklist) AddGroup(groupName string) error {
 		LastActive: time.Now(),
 		Sections: []AdvancedChecklistSection{
 			{
-				Id:        "open-tasks",
-				Name:      "Open",
+				Id:        openTasksSectionID,
+				Name:      openTasksSectionName,
 				Collapsed: false,
 			},
 			{
-				Id:        "completed-tasks",
-				Name:      "Completed",
+				Id:        completedTasksSectionID,
+				Name:      completedTasksSectionName,
 				Collapsed: false,
 			},
 		},

--- a/items/advancedChecklist_test.go
+++ b/items/advancedChecklist_test.go
@@ -130,12 +130,12 @@ func TestAdvancedChecklistToNoteText(t *testing.T) {
 	checklist.SchemaVersion = "1.0.0"
 	checklist.DefaultSections = []DefaultSection{
 		{
-			Id:   "open-tasks",
-			Name: "Open",
+			Id:   openTasksSectionID,
+			Name: openTasksSectionName,
 		},
 		{
-			Id:   "completed-tasks",
-			Name: "Completed",
+			Id:   completedTasksSectionID,
+			Name: completedTasksSectionName,
 		},
 	}
 	checklist.Groups = []AdvancedChecklistGroup{
@@ -144,13 +144,13 @@ func TestAdvancedChecklistToNoteText(t *testing.T) {
 			LastActive: time.Now(),
 			Sections: []AdvancedChecklistSection{
 				{
-					Id:        "open-tasks",
-					Name:      "Open",
+					Id:        openTasksSectionID,
+					Name:      openTasksSectionName,
 					Collapsed: false,
 				},
 				{
-					Id:        "completed-tasks",
-					Name:      "Completed",
+					Id:        completedTasksSectionID,
+					Name:      completedTasksSectionName,
 					Collapsed: false,
 				},
 			},
@@ -173,13 +173,13 @@ func TestAdvancedChecklistToNoteText(t *testing.T) {
 			LastActive: time.Now(),
 			Sections: []AdvancedChecklistSection{
 				{
-					Id:        "open-tasks",
-					Name:      "Open",
+					Id:        openTasksSectionID,
+					Name:      openTasksSectionName,
 					Collapsed: false,
 				},
 				{
-					Id:        "completed-tasks",
-					Name:      "Completed",
+					Id:        completedTasksSectionID,
+					Name:      completedTasksSectionName,
 					Collapsed: false,
 				},
 			},

--- a/items/gosn_test.go
+++ b/items/gosn_test.go
@@ -49,7 +49,7 @@ func localTestMain() {
 }
 
 func TestMain(m *testing.M) {
-	if strings.Contains(os.Getenv("SN_SERVER"), "ramea") {
+	if strings.Contains(os.Getenv(common.EnvServer), "ramea") {
 		localTestMain()
 
 		os.Exit(m.Run())
@@ -59,9 +59,9 @@ func TestMain(m *testing.M) {
 
 	sOutput, err := auth.SignIn(auth.SignInInput{
 		HTTPClient: httpClient,
-		Email:      os.Getenv("SN_EMAIL"),
-		Password:   os.Getenv("SN_PASSWORD"),
-		APIServer:  os.Getenv("SN_SERVER"),
+		Email:      os.Getenv(common.EnvEmail),
+		Password:   os.Getenv(common.EnvPassword),
+		APIServer:  os.Getenv(common.EnvServer),
 		Debug:      true,
 	})
 	if err != nil {
@@ -72,7 +72,7 @@ func TestMain(m *testing.M) {
 		Debug:             true,
 		HTTPClient:        httpClient,
 		SchemaValidation:  false,
-		Server:            os.Getenv("SN_SERVER"),
+		Server:            os.Getenv(common.EnvServer),
 		FilesServerUrl:    sOutput.Session.FilesServerUrl,
 		Token:             "",
 		MasterKey:         sOutput.Session.MasterKey,

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -75,7 +75,7 @@ func TestMakeSessionString(t *testing.T) {
 }
 
 func TestWriteSession(t *testing.T) {
-	if os.Getenv("SN_SKIP_SESSION_TESTS") != "" {
+	if os.Getenv(common.EnvSkipSessionTests) != "" {
 		t.Skip("skipping session test")
 	}
 
@@ -86,7 +86,7 @@ func TestWriteSession(t *testing.T) {
 	var kDefined MockKeyRingDefined
 	require.NoError(t, writeSession("example", kDefined))
 
-	_, _, _ = GetSession(nil, true, "SNServer", os.Getenv("SN_SERVER"), true)
+	_, _, _ = GetSession(nil, true, "SNServer", os.Getenv(common.EnvServer), true)
 
 	require.NoError(t, SessionExists(kDefined))
 }
@@ -115,7 +115,7 @@ func TestWriteSession(t *testing.T) {
 // }
 
 func TestSessionExists(t *testing.T) {
-	if os.Getenv("SN_SKIP_SESSION_TESTS") != "" {
+	if os.Getenv(common.EnvSkipSessionTests) != "" {
 		t.Skip("skipping session test")
 	}
 
@@ -127,7 +127,7 @@ func TestSessionExists(t *testing.T) {
 }
 
 func TestRemoveSession(t *testing.T) {
-	if os.Getenv("SN_SKIP_SESSION_TESTS") != "" {
+	if os.Getenv(common.EnvSkipSessionTests) != "" {
 		t.Skip("skipping session test")
 	}
 
@@ -141,7 +141,7 @@ func TestRemoveSession(t *testing.T) {
 }
 
 func TestSessionStatus(t *testing.T) {
-	if os.Getenv("SN_SKIP_SESSION_TESTS") != "" {
+	if os.Getenv(common.EnvSkipSessionTests) != "" {
 		t.Skip("skipping session test")
 	}
 
@@ -179,15 +179,15 @@ func TestSessionStatus(t *testing.T) {
 }
 
 func TestAddSessionWithoutExistingEnvVars(t *testing.T) {
-	if os.Getenv("SN_SKIP_SESSION_TESTS") != "" {
+	if os.Getenv(common.EnvSkipSessionTests) != "" {
 		t.Skip("skipping session test")
 	}
 
-	_ = os.Unsetenv("SN_SERVER")
-	_ = os.Unsetenv("SN_EMAIL")
-	_ = os.Unsetenv("SN_PASSWORD")
+	_ = os.Unsetenv(common.EnvServer)
+	_ = os.Unsetenv(common.EnvEmail)
+	_ = os.Unsetenv(common.EnvPassword)
 
-	serverURL := os.Getenv("SN_SERVER")
+	serverURL := os.Getenv(common.EnvServer)
 	if serverURL == "" {
 		serverURL = SNServerURL
 	}


### PR DESCRIPTION
## Summary
- reduce duplication by defining environment variable constants
- consolidate section name strings in advanced checklist tests

## Testing
- `go test ./...` *(fails: auth package build issues)*

------
https://chatgpt.com/codex/tasks/task_e_6834e594a1488320b2c1fbe3fd6e4eaf