### PR TITLE
Refactor authentication helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,7 @@ Execute the full test suite using the standard Go tooling:
 go test ./...
 ```
 
-This runs all unit tests across the repository.
+This runs all unit tests across the repository. Some integration tests require
+access to a Standard Notes server. If you don't have credentials or network
+access, set `SN_SKIP_SESSION_TESTS=true` to skip those tests.
 

--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -763,17 +762,39 @@ func (input RegisterInput) Register() (token string, err error) {
 }
 
 func GenerateAuthData(ct, uuid string, kp KeyParams) string {
-	var ad string
-
 	if ct == common.SNItemTypeItemsKey {
-		ad = "{\"kp\":{\"identifier\":\"" + kp.Identifier + "\",\"pw_nonce\":\"" + kp.PwNonce + "\",\"version\":\"" + kp.Version + "\",\"origination\":\"" + kp.Origination + "\",\"created\":\"" + kp.Created + "\"},\"u\":\"" + uuid + "\",\"v\":\"" + kp.Version + "\"}"
+		ad := struct {
+			KP KeyParams `json:"kp"`
+			U  string    `json:"u"`
+			V  string    `json:"v"`
+		}{
+			KP: kp,
+			U:  uuid,
+			V:  kp.Version,
+		}
 
-		return ad
+		b, err := json.Marshal(ad)
+		if err != nil {
+			panic(err)
+		}
+
+		return string(b)
 	}
 
-	ad = "{\"u\":\"" + uuid + "\",\"v\":\"004\"}"
+	ad := struct {
+		U string `json:"u"`
+		V string `json:"v"`
+	}{
+		U: uuid,
+		V: common.DefaultSNVersion,
+	}
 
-	return ad
+	b, err := json.Marshal(ad)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(b)
 }
 
 func generateInitialKeysAndAuthParamsForUser(email, password string) (pw, pwNonce, masterKey, serverPassword string, err error) {

--- a/auth/generate_auth_data_test.go
+++ b/auth/generate_auth_data_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jonhadfield/gosn-v2/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAuthDataItemsKey(t *testing.T) {
+	kp := KeyParams{
+		Created:     "123",
+		Identifier:  "user@example.com",
+		Origination: "registration",
+		PwNonce:     "nonce",
+		Version:     "004",
+	}
+
+	data := GenerateAuthData(common.SNItemTypeItemsKey, "uuid1", kp)
+
+	var out struct {
+		KP KeyParams `json:"kp"`
+		U  string    `json:"u"`
+		V  string    `json:"v"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(data), &out))
+	require.Equal(t, kp, out.KP)
+	require.Equal(t, "uuid1", out.U)
+	require.Equal(t, kp.Version, out.V)
+}
+
+func TestGenerateAuthDataDefault(t *testing.T) {
+	kp := KeyParams{Version: "004"}
+
+	data := GenerateAuthData(common.SNItemTypeNote, "uuid2", kp)
+
+	var out map[string]string
+	require.NoError(t, json.Unmarshal([]byte(data), &out))
+	require.Equal(t, "uuid2", out["u"])
+	require.Equal(t, "004", out["v"])
+}

--- a/common/env_test.go
+++ b/common/env_test.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEnvInt64Unset(t *testing.T) {
+	os.Unsetenv("TEST_INT64")
+	val, ok, err := ParseEnvInt64("TEST_INT64")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, int64(0), val)
+}
+
+func TestParseEnvInt64Valid(t *testing.T) {
+	os.Setenv("TEST_INT64", "42")
+	defer os.Unsetenv("TEST_INT64")
+
+	val, ok, err := ParseEnvInt64("TEST_INT64")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, int64(42), val)
+}
+
+func TestParseEnvInt64Invalid(t *testing.T) {
+	os.Setenv("TEST_INT64", "abc")
+	defer os.Unsetenv("TEST_INT64")
+
+	_, ok, err := ParseEnvInt64("TEST_INT64")
+	require.Error(t, err)
+	require.False(t, ok)
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jonhadfield/gosn-v2/common"
+
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## Summary
- refactor `GenerateAuthData` to build JSON via `json.Marshal`
- add coverage for `GenerateAuthData` and `ParseEnvInt64`
- fix `session_test` imports
- document how to skip integration tests

## Testing
- `go test ./common`


------
https://chatgpt.com/codex/tasks/task_e_683c422857ec8320aa4498876a59edfd