### PR TITLE
Refactor: replace magic numbers with constants

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -38,6 +38,8 @@ type SyncToken struct {
 	SyncToken string `storm:"id,unique"`
 }
 
+const batchSize = 500
+
 type SyncInput struct {
 	*Session
 	Close bool
@@ -317,8 +319,6 @@ func SaveCacheItems(db *storm.DB, items Items, close bool) error {
 		return fmt.Errorf("db not passed to SaveCacheItems")
 	}
 
-	batchSize := 500
-
 	total := len(items)
 
 	for i := 0; i < total; i += batchSize {
@@ -370,8 +370,6 @@ func DeleteCacheItems(db *storm.DB, items Items, close bool) error {
 	if db == nil {
 		return fmt.Errorf("db not passed to DeleteCacheItems")
 	}
-
-	batchSize := 500
 
 	total := len(items)
 
@@ -429,8 +427,6 @@ func CleanCacheItems(db *storm.DB, items Items, close bool) error {
 	if db == nil {
 		return fmt.Errorf("db not passed to DeleteCacheItems")
 	}
-
-	batchSize := 500
 
 	total := len(items)
 

--- a/common/common.go
+++ b/common/common.go
@@ -76,9 +76,9 @@ func NewHTTPClient() *retryablehttp.Client {
 		t.Proxy = http.ProxyURL(proxyUrl)
 	}
 
-	t.MaxIdleConns = 100
-	t.MaxConnsPerHost = 100
-	t.MaxIdleConnsPerHost = 100
+	t.MaxIdleConns = MaxIdleConnections
+	t.MaxConnsPerHost = MaxIdleConnections
+	t.MaxIdleConnsPerHost = MaxIdleConnections
 	c.HTTPClient.Transport = t
 
 	c.RetryMax = MaxRequestRetries


### PR DESCRIPTION
## Summary
- use MaxIdleConnections constant for HTTP transport
- add package-level batchSize constant for cache updates
- define statusInvalidToken constant for items
- swap HTTP status numbers for constants

## Testing
- `go vet ./...`
- `go test ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683c93178e60832099728a8c65aff978