### PR TITLE
Refactor cache functions and error handling

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,8 @@ import (
 	"github.com/jonhadfield/gosn-v2/session"
 	"github.com/mitchellh/go-homedir"
 )
+
+const batchSize = 500
 
 type Item struct {
 	UUID               string `storm:"id,unique"`
@@ -80,7 +83,9 @@ func (s *Session) gosn() *session.Session {
 	return &gs
 }
 
-func (pi Items) ToItems(s *Session) (its items.Items, err error) {
+func (pi Items) ToItems(s *Session) (items.Items, error) {
+	var its items.Items
+	var err error
 	log.DebugPrint(s.Debug, fmt.Sprintf("ToItems | Converting %d cache items to gosn items", len(pi)), common.MaxDebugChars)
 
 	// start := time.Now()
@@ -135,13 +140,13 @@ func (pi Items) ToItems(s *Session) (its items.Items, err error) {
 
 		its, err = eItems.DecryptAndParse(s.Session)
 		if err != nil {
-			return
+			return items.Items{}, err
 		}
 	}
 
 	// log.DebugPrint(s.Debug, fmt.Sprintf("ToItems took: %s", time.Since(start).String()), 50)
 
-	return
+	return its, nil
 }
 
 // func (s *Session) Export(path string) error {
@@ -247,7 +252,7 @@ func ToCacheItems(items items.EncryptedItems, clean bool) (pitems Items) {
 		pitems = append(pitems, cItem)
 	}
 
-	return
+	return pitems
 }
 
 // SaveNotes encrypts, converts to cache items, and then persists to db.
@@ -284,11 +289,11 @@ func SaveEncryptedItems(db *storm.DB, items items.EncryptedItems, close bool) er
 // SaveItems saves Items to the provided database.
 func SaveItems(s *Session, db *storm.DB, its items.Items, close bool) error {
 	if len(its) == 0 {
-		return fmt.Errorf("no items provided to SaveItems")
+		return errors.New("no items provided to SaveItems")
 	}
 
 	if db == nil {
-		return fmt.Errorf("db not passed to SaveItems")
+		return errors.New("db not passed to SaveItems")
 	}
 
 	var eItems items.EncryptedItems
@@ -310,14 +315,12 @@ func SaveItems(s *Session, db *storm.DB, its items.Items, close bool) error {
 // SaveCacheItems saves Cache Items to the provided database.
 func SaveCacheItems(db *storm.DB, items Items, close bool) error {
 	if len(items) == 0 {
-		return fmt.Errorf("no items provided to SaveCacheItems")
+		return errors.New("no items provided to SaveCacheItems")
 	}
 
 	if db == nil {
-		return fmt.Errorf("db not passed to SaveCacheItems")
+		return errors.New("db not passed to SaveCacheItems")
 	}
-
-	batchSize := 500
 
 	total := len(items)
 
@@ -364,14 +367,12 @@ func SaveCacheItems(db *storm.DB, items Items, close bool) error {
 // DeleteCacheItems saves Cache Items to the provided database.
 func DeleteCacheItems(db *storm.DB, items Items, close bool) error {
 	if len(items) == 0 {
-		return fmt.Errorf("no items provided to DeleteCacheItems")
+		return errors.New("no items provided to DeleteCacheItems")
 	}
 
 	if db == nil {
-		return fmt.Errorf("db not passed to DeleteCacheItems")
+		return errors.New("db not passed to DeleteCacheItems")
 	}
-
-	batchSize := 500
 
 	total := len(items)
 
@@ -423,14 +424,12 @@ func DeleteCacheItems(db *storm.DB, items Items, close bool) error {
 // CleanCacheItems marks Cache Items as clean (Dirty = false) and resets dirtied date to the provided database.
 func CleanCacheItems(db *storm.DB, items Items, close bool) error {
 	if len(items) == 0 {
-		return fmt.Errorf("no items provided to DeleteCacheItems")
+		return errors.New("no items provided to DeleteCacheItems")
 	}
 
 	if db == nil {
-		return fmt.Errorf("db not passed to DeleteCacheItems")
+		return errors.New("db not passed to DeleteCacheItems")
 	}
-
-	batchSize := 500
 
 	total := len(items)
 
@@ -545,7 +544,8 @@ func (i Items) ValidateSaved() error {
 	return nil
 }
 
-func retrieveItemsKeysFromCache(s *session.Session, i Items) (encryptedItemKeys items.EncryptedItems, err error) {
+func retrieveItemsKeysFromCache(s *session.Session, i Items) (items.EncryptedItems, error) {
+	var encryptedItemKeys items.EncryptedItems
 	log.DebugPrint(s.Debug, "retrieveItemsKeysFromCache | attempting to retrieve items key(s) from cache", common.MaxDebugChars)
 
 	for x := range i {
@@ -568,21 +568,21 @@ func retrieveItemsKeysFromCache(s *session.Session, i Items) (encryptedItemKeys 
 		}
 	}
 
-	return
+	return encryptedItemKeys, nil
 }
 
 // Sync will push any dirty items to SN and make database cache consistent with SN.
 func Sync(si SyncInput) (so SyncOutput, err error) {
 	// check session is valid
 	if si.Session == nil || !si.Session.Valid() {
-		err = fmt.Errorf("invalid session")
+		err = errors.New("invalid session")
 
 		return
 	}
 
 	// only path should be passed
 	if si.Session.CacheDBPath == "" {
-		err = fmt.Errorf("database path is required")
+		err = errors.New("database path is required")
 		return
 	}
 
@@ -1017,7 +1017,8 @@ func processCachedItemsKeys(s *Session, eiks items.EncryptedItems) error {
 	return err
 }
 
-func mergeItemsKeysSlices(sessionList, another []session.SessionItemsKey) (out []session.SessionItemsKey) {
+func mergeItemsKeysSlices(sessionList, another []session.SessionItemsKey) []session.SessionItemsKey {
+	var out []session.SessionItemsKey
 	var holdingList []session.SessionItemsKey
 
 	for _, s := range sessionList {
@@ -1064,7 +1065,7 @@ func mergeItemsKeysSlices(sessionList, another []session.SessionItemsKey) (out [
 		}
 	}
 
-	return
+	return out
 }
 
 // GenCacheDBPath generates a path to a database file to be used as a cache of encrypted items
@@ -1075,7 +1076,7 @@ func mergeItemsKeysSlices(sessionList, another []session.SessionItemsKey) (out [
 // - the requesting application name (so that caches are application specific).
 func GenCacheDBPath(session Session, dir, appName string) (string, error) {
 	if !session.Valid() || appName == "" {
-		return "", fmt.Errorf("invalid session or appName")
+		return "", errors.New("invalid session or appName")
 	}
 
 	if dir == "" {

--- a/cache/session.go
+++ b/cache/session.go
@@ -16,7 +16,9 @@ type Session struct {
 
 // ImportSession creates a new Session from an existing gosn.Session instance
 // with the option of specifying a path for the db other than the home folder.
-func ImportSession(gs *auth.SignInResponseDataSession, path string) (s *Session, err error) {
+func ImportSession(gs *auth.SignInResponseDataSession, path string) (*Session, error) {
+	var err error
+	var s *Session
 	if gs == nil {
 		panic("gs is nil")
 	}
@@ -54,12 +56,12 @@ func ImportSession(gs *auth.SignInResponseDataSession, path string) (s *Session,
 
 		dbPath, err = GenCacheDBPath(*s, dbPath, common.LibName)
 		if err != nil {
-			return
+			return nil, err
 		}
 
 		s.CacheDBPath = dbPath
 
-		return
+		return s, nil
 	}
 
 	s.CacheDBPath = path
@@ -70,17 +72,19 @@ func ImportSession(gs *auth.SignInResponseDataSession, path string) (s *Session,
 
 // GetSession returns a cache session that encapsulates a gosn-v2 session with additional
 // configuration for managing a local cache database.
-func GetSession(httpClient *retryablehttp.Client, loadSession bool, sessionKey, server string, debug bool) (s Session, email string, err error) {
+func GetSession(httpClient *retryablehttp.Client, loadSession bool, sessionKey, server string, debug bool) (Session, string, error) {
 	var gs session.Session
+	var email string
+	var err error
 
 	if httpClient == nil || httpClient.HTTPClient == nil {
 		httpClient = common.NewHTTPClient()
 	}
 
-	gs, _, err = session.GetSession(httpClient, loadSession, sessionKey, server, debug)
+	gs, email, err = session.GetSession(httpClient, loadSession, sessionKey, server, debug)
 
 	if err != nil {
-		return
+		return Session{}, "", err
 	}
 
 	cs := Session{


### PR DESCRIPTION
## Summary
- remove named return parameters in cache package helpers
- replace fmt.Errorf with errors.New when formatting not required
- introduce batch size constant to avoid magic numbers
- adjust return statements accordingly

## Testing
- `go test ./...` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_683c994cc2d08320aff79942f419fe00