### PR TITLE
Fix vet issues and constant

### DIFF
--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -551,7 +552,7 @@ func SignIn(input SignInInput) (output SignInOutput, err error) {
 	}
 
 	if requestTokenFailure.Data.Error.Message != "" {
-		err = fmt.Errorf(strings.ToLower(requestTokenFailure.Data.Error.Message))
+		err = errors.New(strings.ToLower(requestTokenFailure.Data.Error.Message))
 		return
 	}
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -41,8 +41,6 @@ type SyncToken struct {
 	SyncToken string `storm:"id,unique"`
 }
 
-const batchSize = 500
-
 type SyncInput struct {
 	*Session
 	Close bool

--- a/items/itemDecryption.go
+++ b/items/itemDecryption.go
@@ -11,9 +11,7 @@ import (
 
 func DecryptItem(e EncryptedItem, s *session.Session, iks []session.SessionItemsKey) (o DecryptedItem, err error) {
 	if e.Deleted {
-		err = fmt.Errorf(fmt.Sprintf("cannot decrypt deleted item: %s %s", e.ContentType, e.UUID))
-
-		return
+		return o, fmt.Errorf("cannot decrypt deleted item: %s %s", e.ContentType, e.UUID)
 	}
 
 	var key string


### PR DESCRIPTION
## Summary
- remove duplicate `batchSize` constant
- return error for deleted items correctly
- use `errors.New` instead of `fmt.Errorf` with variable format string

## Testing
- `go vet ./...`
- `go test ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683df0ce23a88320b6b99f03dddf84a5