### PR TITLE
Reduce repetition in item dedupe methods

### DIFF
--- a/items/component.go
+++ b/items/component.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -73,19 +72,7 @@ func (i Items) Components() (c Components) {
 }
 
 func (c *Components) DeDupe() {
-	var encountered []string
-
-	var deDuped Components
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewComponent returns an Item of type Component without content.

--- a/items/dedupe.go
+++ b/items/dedupe.go
@@ -1,0 +1,19 @@
+package items
+
+// DeDupeByUUID returns a new slice containing only the first occurrence of each
+// item as identified by its UUID.
+func DeDupeByUUID[T interface{ GetUUID() string }](in []T) []T {
+	encountered := make(map[string]struct{})
+	out := make([]T, 0, len(in))
+
+	for _, v := range in {
+		id := v.GetUUID()
+		if _, ok := encountered[id]; ok {
+			continue
+		}
+		encountered[id] = struct{}{}
+		out = append(out, v)
+	}
+
+	return out
+}

--- a/items/extension.go
+++ b/items/extension.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -61,19 +60,7 @@ func (i Items) Extension() (c Extensions) {
 }
 
 func (c *Extensions) DeDupe() {
-	var encountered []string
-
-	var deDuped Extensions
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewExtension returns an Item of type Extension without content.

--- a/items/extensionRepo.go
+++ b/items/extensionRepo.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -61,19 +60,7 @@ func (i Items) ExtensionRepo() (c ExtensionRepos) {
 }
 
 func (c *ExtensionRepos) DeDupe() {
-	var encountered []string
-
-	var deDuped ExtensionRepos
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewExtensionRepo returns an Item of type ExtensionRepo without content.

--- a/items/file.go
+++ b/items/file.go
@@ -65,19 +65,7 @@ func (i Items) File() (c Files) {
 }
 
 func (c *Files) DeDupe() {
-	var encountered []string
-
-	var deDuped Files
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewFile returns an Item of type File without content.

--- a/items/fileSafeCredentials.go
+++ b/items/fileSafeCredentials.go
@@ -3,7 +3,6 @@ package items
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -65,19 +64,7 @@ func (i Items) FileSafeCredentials() (c FileSafeCredentialss) {
 }
 
 func (c *FileSafeCredentialss) DeDupe() {
-	var encountered []string
-
-	var deDuped FileSafeCredentialss
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewFileSafeCredentials returns an Item of type FileSafeCredentials without content.

--- a/items/fileSafeFileMetadata.go
+++ b/items/fileSafeFileMetadata.go
@@ -3,7 +3,6 @@ package items
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -63,19 +62,7 @@ func (i Items) FileSafeFileMetaData() (c FileSafeFileMetaDatas) {
 }
 
 func (c *FileSafeFileMetaDatas) DeDupe() {
-	var encountered []string
-
-	var deDuped FileSafeFileMetaDatas
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewFileSafeFileMetaData returns an Item of type FileSafeFileMetaData without content.

--- a/items/fileSafeIntegration.go
+++ b/items/fileSafeIntegration.go
@@ -66,19 +66,7 @@ func (i Items) FileSafeIntegration() (c FileSafeIntegrations) {
 }
 
 func (c *FileSafeIntegrations) DeDupe() {
-	var encountered []string
-
-	var deDuped FileSafeIntegrations
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewFileSafeIntegration returns an Item of type FileSafeIntegration without content.

--- a/items/items.go
+++ b/items/items.go
@@ -874,17 +874,7 @@ func (ei *EncryptedItems) RemoveDeleted() {
 }
 
 func (i *Items) DeDupe() {
-	encountered := make(map[string]struct{})
-	deDuped := make(Items, 0, len(*i))
-
-	for _, j := range *i {
-		if _, ok := encountered[j.GetUUID()]; !ok {
-			encountered[j.GetUUID()] = struct{}{}
-			deDuped = append(deDuped, j)
-		}
-	}
-
-	*i = deDuped
+	*i = DeDupeByUUID(*i)
 }
 
 func (i *Items) RemoveDeleted() {

--- a/items/note.go
+++ b/items/note.go
@@ -3,7 +3,6 @@ package items
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -59,19 +58,7 @@ func (i Items) Notes() (n Notes) {
 }
 
 func (n *Notes) DeDupe() {
-	var encountered []string
-
-	var deDuped Notes
-
-	for _, i := range *n {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*n = deDuped
+	*n = DeDupeByUUID(*n)
 }
 
 func (n *Notes) Encrypt(s session.Session) (e EncryptedItems, err error) {

--- a/items/privileges.go
+++ b/items/privileges.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -61,19 +60,7 @@ func (i Items) Privileges() (c PrivilegesN) {
 }
 
 func (c *PrivilegesN) DeDupe() {
-	var encountered []string
-
-	var deDuped PrivilegesN
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewPrivileges returns an Item of type Privileges without content.

--- a/items/sfExtension.go
+++ b/items/sfExtension.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -63,19 +62,7 @@ func (i Items) SFExtension() (c SFExtensions) {
 }
 
 func (c *SFExtensions) DeDupe() {
-	var encountered []string
-
-	var deDuped SFExtensions
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewSFExtension returns an Item of type SFExtension without content.

--- a/items/sfMFA.go
+++ b/items/sfMFA.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -63,19 +62,7 @@ func (i Items) SFMFA() (c SFMFAs) {
 }
 
 func (c *SFMFAs) DeDupe() {
-	var encountered []string
-
-	var deDuped SFMFAs
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewSFMFA returns an Item of type SFMFA without content.

--- a/items/smartTag.go
+++ b/items/smartTag.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -61,19 +60,7 @@ func (i Items) SmartTag() (c SmartTags) {
 }
 
 func (c *SmartTags) DeDupe() {
-	var encountered []string
-
-	var deDuped SmartTags
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewSmartTag returns an Item of type SmartTag without content.

--- a/items/tag.go
+++ b/items/tag.go
@@ -3,7 +3,6 @@ package items
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -56,19 +55,7 @@ func (i Items) Tags() (t Tags) {
 }
 
 func (t *Tags) DeDupe() {
-	var encountered []string
-
-	var deDuped Tags
-
-	for _, i := range *t {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*t = deDuped
+	*t = DeDupeByUUID(*t)
 }
 
 func (t *Tags) Encrypt(s session.Session) (e EncryptedItems, err error) {

--- a/items/theme.go
+++ b/items/theme.go
@@ -3,7 +3,6 @@ package items
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -66,19 +65,7 @@ func (i Items) Themes() (c Themes) {
 }
 
 func (c *Themes) DeDupe() {
-	var encountered []string
-
-	var deDuped Themes
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewTheme returns an Item of type Theme without content.

--- a/items/userPreferences.go
+++ b/items/userPreferences.go
@@ -2,7 +2,6 @@ package items
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jonhadfield/gosn-v2/common"
@@ -75,19 +74,7 @@ func (i Items) UserPreferences() (c UserPreferencess) {
 }
 
 func (c *UserPreferencess) DeDupe() {
-	var encountered []string
-
-	var deDuped UserPreferencess
-
-	for _, i := range *c {
-		if !slices.Contains(encountered, i.UUID) {
-			deDuped = append(deDuped, i)
-		}
-
-		encountered = append(encountered, i.UUID)
-	}
-
-	*c = deDuped
+	*c = DeDupeByUUID(*c)
 }
 
 // NewUserPreferences returns an Item of type UserPreferences without content.


### PR DESCRIPTION
## Summary
- add generic `DeDupeByUUID` helper
- simplify `DeDupe` methods for item collections

## Testing
- `go test ./...` *(fails: http invalid host header)*

------
https://chatgpt.com/codex/tasks/task_e_685e3fe1b7fc832099e2111731bff809