### PR TITLE
Reduce test setup duplication

### DIFF
--- a/items/gosn_test.go
+++ b/items/gosn_test.go
@@ -1,18 +1,16 @@
 package items
 
 import (
-	"fmt"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jonhadfield/gosn-v2/auth"
 	"github.com/jonhadfield/gosn-v2/common"
 	"github.com/jonhadfield/gosn-v2/schemas"
 	"github.com/jonhadfield/gosn-v2/session"
+	"github.com/jonhadfield/gosn-v2/testutil"
 )
 
 var (
@@ -22,30 +20,11 @@ var (
 )
 
 func localTestMain() {
-	localServer := "http://ramea:3000"
-	testUserEmail = fmt.Sprintf("ramea-%s", strconv.FormatInt(time.Now().UnixNano(), 16))
-	testUserPassword = "secretsanta"
-
-	rInput := auth.RegisterInput{
-		Password:  testUserPassword,
-		Email:     testUserEmail,
-		APIServer: localServer,
-		Version:   common.DefaultSNVersion,
-		Debug:     true,
-	}
-
-	_, err := rInput.Register()
+	var err error
+	testUserEmail, testUserPassword, err = testutil.RegisterAndSignInLocalUser()
 	if err != nil {
-		panic(fmt.Sprintf("failed to register with: %s", localServer))
+		panic(err)
 	}
-
-	// auth.SignIn(localServer, testUserEmail, testUserPassword)
-	auth.SignIn(auth.SignInInput{
-		Email:     testUserEmail,
-		Password:  testUserPassword,
-		APIServer: localServer,
-		Debug:     false,
-	})
 }
 
 func TestMain(m *testing.M) {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,46 @@
+package testutil
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/gosn-v2/auth"
+	"github.com/jonhadfield/gosn-v2/common"
+)
+
+// RegisterAndSignInLocalUser registers and signs in a user on a local
+// Standard Notes server used for testing. It returns the generated email
+// and password used for the account.
+func RegisterAndSignInLocalUser() (email, password string, err error) {
+	localServer := "http://ramea:3000"
+	email = fmt.Sprintf("ramea-%s", strconv.FormatInt(time.Now().UnixNano(), 16))
+	password = "secretsanta"
+
+	rInput := auth.RegisterInput{
+		Client:    retryablehttp.NewClient(),
+		Password:  password,
+		Email:     email,
+		APIServer: localServer,
+		Version:   common.DefaultSNVersion,
+		Debug:     true,
+	}
+
+	if _, err = rInput.Register(); err != nil {
+		return "", "", fmt.Errorf("failed to register with: %s", localServer)
+	}
+
+	_, err = auth.SignIn(auth.SignInInput{
+		HTTPClient: retryablehttp.NewClient(),
+		Email:      email,
+		Password:   password,
+		APIServer:  localServer,
+		Debug:      false,
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	return email, password, nil
+}


### PR DESCRIPTION
## Summary
- create `testutil` package with `RegisterAndSignInLocalUser`
- reuse new helper in tests
- adjust auth tests to external package

## Testing
- `SN_SKIP_SESSION_TESTS=1 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e3fe1b7fc832099e2111731bff809