### PR TITLE
Refactor random string generation

### DIFF
--- a/auth/random.go
+++ b/auth/random.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
+
+	"github.com/jonhadfield/gosn-v2/log"
+)
+
+// cryptoSource allows math/rand to use crypto/rand for randomness.
+type cryptoSource struct{}
+
+func (s cryptoSource) Seed(seed int64) {}
+
+func (s cryptoSource) Int63() int64 {
+	return int64(s.Uint64() & ^uint64(1<<63))
+}
+
+func (s cryptoSource) Uint64() (v uint64) {
+	if err := binary.Read(crand.Reader, binary.BigEndian, &v); err != nil {
+		log.Fatal(err.Error())
+	}
+	return v
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+// randomString returns a crypto-random string of the requested length.
+func randomString(n int) string {
+	var src cryptoSource
+	rnd := rand.New(src)
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rnd.Intn(len(letterRunes))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary
- extract `randomString` helper to generate crypto-safe strings
- use helper when generating password nonces and login verifiers

## Testing
- `SN_SKIP_SESSION_TESTS=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e3fe1b7fc832099e2111731bff809