### PR TITLE
Send SN client identification headers on all API requests

### DIFF
--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -107,6 +107,7 @@ func RequestRefreshToken(client *retryablehttp.Client, url, accessToken, refresh
 
 	refreshSessionReq.Header.Set(common.HeaderContentType, common.SNAPIContentType)
 	refreshSessionReq.Header.Set("Connection", "keep-alive")
+	common.SetStandardClientHeaders(refreshSessionReq.Header)
 
 	// For cookie-based sessions, we need more context to set proper cookies
 	// This function signature is limited - we need session context to extract actual cookie values
@@ -183,6 +184,7 @@ func requestToken(input signInInput) (signInSuccess signInResponse, signInFailur
 
 	signInURLReq.Header.Set(common.HeaderContentType, common.SNAPIContentType)
 	signInURLReq.Header.Set("Connection", "keep-alive")
+	common.SetStandardClientHeaders(signInURLReq.Header)
 
 	var signInResp *http.Response
 
@@ -354,6 +356,7 @@ func doAuthParamsRequest(input authParamsInput) (output doAuthRequestOutput, err
 
 	req.Header.Set(common.HeaderContentType, common.SNAPIContentType)
 	req.Header.Set("Connection", "keep-alive")
+	common.SetStandardClientHeaders(req.Header)
 
 	var response *http.Response
 
@@ -694,6 +697,7 @@ func RequestRefreshTokenWithSession(session *SignInResponseDataSession, url stri
 
 	refreshSessionReq.Header.Set(common.HeaderContentType, common.SNAPIContentType)
 	refreshSessionReq.Header.Set("Connection", "keep-alive")
+	common.SetStandardClientHeaders(refreshSessionReq.Header)
 
 	// For cookie-based authentication (tokens starting with "2:"), we need BOTH Cookie and Authorization headers
 	accessParts := strings.Split(session.AccessToken, ":")
@@ -878,6 +882,7 @@ func (input RegisterInput) Register() (token string, err error) {
 
 	req.Header.Set(common.HeaderContentType, common.SNAPIContentType)
 	req.Header.Set("Connection", "keep-alive")
+	common.SetStandardClientHeaders(req.Header)
 
 	// Note: req.Host should not be set manually - it's automatically derived from the URL
 	// Setting it to the full URL (e.g., "https://api.standardnotes.com") causes "http2: invalid Host header"

--- a/common/client_headers.go
+++ b/common/client_headers.go
@@ -1,0 +1,28 @@
+package common
+
+import "net/http"
+
+// Client identification headers required by the Standard Notes API gateway.
+//
+// As of 2026-05, requests missing X-SNJS-Version or X-Application-Version are
+// rejected with HTTP 400 and the message "Your client version is no longer
+// supported." The gateway gates on these headers rather than the api field in
+// the request body, so they must be present on every auth and sync request.
+//
+// The values below mirror what the official Standard Notes client sends. When
+// the gateway bumps its minimum-supported client version again, update these
+// constants to track the current standardnotes/app release.
+const (
+	SNUserAgent  = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) StandardNotes/3.198.18 Chrome/134.0.6998.205 Electron/35.2.0 Safari/537.36"
+	SNJSVersion  = "2.211.7"
+	SNAppVersion = "Desktop-3.201.27"
+)
+
+// SetStandardClientHeaders sets the User-Agent and SN-specific version headers
+// the API gateway requires to accept a request. Call this on any outbound
+// request to api.standardnotes.com (auth, sync, refresh, registration).
+func SetStandardClientHeaders(h http.Header) {
+	h.Set("User-Agent", SNUserAgent)
+	h.Set("X-SNJS-Version", SNJSVersion)
+	h.Set("X-Application-Version", SNAppVersion)
+}

--- a/common/client_headers_test.go
+++ b/common/client_headers_test.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetStandardClientHeaders(t *testing.T) {
+	h := http.Header{}
+	SetStandardClientHeaders(h)
+
+	tests := map[string]string{
+		"User-Agent":            SNUserAgent,
+		"X-SNJS-Version":        SNJSVersion,
+		"X-Application-Version": SNAppVersion,
+	}
+
+	for header, expected := range tests {
+		if got := h.Get(header); got != expected {
+			t.Errorf("%s: got %q, want %q", header, got, expected)
+		}
+	}
+}
+
+func TestSetStandardClientHeaders_OverwritesExisting(t *testing.T) {
+	h := http.Header{}
+	h.Set("User-Agent", "stale")
+	h.Set("X-SNJS-Version", "stale")
+	h.Set("X-Application-Version", "stale")
+
+	SetStandardClientHeaders(h)
+
+	if got := h.Get("User-Agent"); got != SNUserAgent {
+		t.Errorf("User-Agent not overwritten: got %q", got)
+	}
+	if got := h.Get("X-SNJS-Version"); got != SNJSVersion {
+		t.Errorf("X-SNJS-Version not overwritten: got %q", got)
+	}
+	if got := h.Get("X-Application-Version"); got != SNAppVersion {
+		t.Errorf("X-Application-Version not overwritten: got %q", got)
+	}
+}

--- a/items/items.go
+++ b/items/items.go
@@ -523,7 +523,7 @@ func makeSyncRequest(session *session.Session, reqBody []byte) (responseBody []b
 		log.DebugPrint(session.Debug, "Using header-based authentication (Authorization header only)", common.MaxDebugChars)
 	}
 
-	request.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) StandardNotes/3.198.18 Chrome/134.0.6998.205 Electron/35.2.0 Safari/537.36")
+	common.SetStandardClientHeaders(request.Header)
 
 	// Create a context with timeout for the request
 	timeout := common.RequestTimeout
@@ -657,7 +657,7 @@ func makeSyncRequest(session *session.Session, reqBody []byte) (responseBody []b
 				}
 				request.Header.Set(common.HeaderContentType, common.SNAPIContentType)
 				request.Header.Set("Authorization", "Bearer "+session.AccessToken)
-				request.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) StandardNotes/3.198.18 Chrome/134.0.6998.205 Electron/35.2.0 Safari/537.36")
+				common.SetStandardClientHeaders(request.Header)
 				request = request.WithContext(ctx)
 
 				continue // Retry the request
@@ -828,7 +828,7 @@ func makeSyncRequest(session *session.Session, reqBody []byte) (responseBody []b
 		}
 		retryRequest.Header.Set(common.HeaderContentType, common.SNAPIContentType)
 		retryRequest.Header.Set("Authorization", "Bearer "+session.AccessToken)
-		retryRequest.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) StandardNotes/3.198.18 Chrome/134.0.6998.205 Electron/35.2.0 Safari/537.36")
+		common.SetStandardClientHeaders(retryRequest.Header)
 		retryRequest = retryRequest.WithContext(ctx)
 
 		log.DebugPrint(session.Debug, "makeSyncRequest | retrying request with refreshed token", common.MaxDebugChars)


### PR DESCRIPTION
## Summary

The Standard Notes API at `api.standardnotes.com` returns HTTP 400 *"Your client version is no longer supported. Please update Standard Notes to the latest version to continue."* on auth and sync requests that omit the `X-SNJS-Version` and `X-Application-Version` headers. Both headers must accompany every request; without them, no `gosn-v2` request currently reaches the auth or sync services. The visible symptom in `sn-cli` is *"invalid session found in keyring."*

## Evidence

**1. The rejection is reproducible at the HTTP layer.**

Before — `api:"20240226"` with only `Content-Type`:

```
$ curl -i -X POST https://api.standardnotes.com/v2/login-params \
    -H 'Content-Type: application/json' \
    -d '{"email":"x@example.com","api":"20240226","code_challenge":"<86 chars>"}'

HTTP/2 400
content-length: 131
x-api-gateway-version: 5825ed56
...
{"error":{"message":"Your client version is no longer supported. Please update Standard Notes to the latest version to continue."}}
```

After — same request with the two SN-specific headers and a matching User-Agent added:

```
$ curl -i -X POST https://api.standardnotes.com/v2/login-params \
    -H 'Content-Type: application/json' \
    -H 'X-SNJS-Version: 2.211.7' \
    -H 'X-Application-Version: Desktop-3.201.27' \
    -H 'User-Agent: Mozilla/5.0 (...) StandardNotes/3.198.18 (...)' \
    -d '{"email":"x@example.com","api":"20240226","code_challenge":"<86 chars>"}'

HTTP/2 200
...
{"meta":{...},"data":{"identifier":"x@example.com","pw_nonce":"...","version":"004"}}
```

The `x-api-gateway-version` response header and the absence of the *"client version no longer supported"* string from any open `standardnotes/server` source ([search](https://github.com/search?q=org%3Astandardnotes+%22Your+client+version+is+no+longer+supported%22&type=code) returns no results) point at an API-gateway-level rejection, not an auth-service rejection. I haven't isolated which header is individually load-bearing — only that the official client's set is sufficient and the empty set is not.

**2. The official client sends these three headers.**

`standardnotes/app` — [`packages/api/src/Domain/Http/FetchRequestHandler.ts:37-46`](https://github.com/standardnotes/app/blob/main/packages/api/src/Domain/Http/FetchRequestHandler.ts):

```ts
const headers: Record<string, string> = {}
...
headers['X-SNJS-Version'] = this.snjsVersion
const appVersionHeaderValue = `${Environment[this.environment]}-${this.appVersion}`
headers['X-Application-Version'] = appVersionHeaderValue
```

The corresponding `Content-Type: application/json` is set further down at line 60.

**3. The version values track the current `standardnotes/app` release.**

- `SNJSVersion = "2.211.7"` — from [`packages/snjs/package.json`](https://github.com/standardnotes/app/blob/main/packages/snjs/package.json) `"version"`.
- `SNAppVersion = "Desktop-3.201.27"` — from [`packages/web/package.json`](https://github.com/standardnotes/app/blob/main/packages/web/package.json) `"version"`, prefixed with the desktop environment marker per the `${Environment[env]}-${appVersion}` template above.
- `SNUserAgent` — the literal already inlined three times in `items/items.go` on `master`.

**4. The misleading `"invalid session found in keyring"` user message.**

`session/session.go:476` returns this error when `rawSess` parses but contains `"access_token":""`. That state is reached when the failed sign-in response is unmarshalled into the `signInSuccess` struct (defaults to zero-value fields) and `writeSession` persists it to the keyring. The user then sees a "you have an invalid session" message on the *next* command, with no indication that the original sign-in was rejected upstream.

This PR doesn't change that error-handling behavior — it just removes the precondition that produces the empty session in the first place.

## What this PR does

1. **`common/client_headers.go`** — adds `SNUserAgent`, `SNJSVersion`, `SNAppVersion` constants and a `SetStandardClientHeaders(h http.Header)` helper. Single source of truth for future bumps.
2. **`auth/authentication.go`** — calls the helper on all five outbound auth requests (login-params probe, sign-in, two refresh paths, registration).
3. **`items/items.go`** — replaces the existing inlined `User-Agent` literal at the three sync sites with the helper (also picks up the previously-missing `X-SNJS-Version` / `X-Application-Version`).
4. **`common/client_headers_test.go`** — unit test on the helper's contract (sets all three headers; overwrites pre-existing values).

When the SN API raises its minimum-supported client version again, only the three constants in `common/client_headers.go` need updating.

## End-to-end verification

`sn-cli` built against this branch, against a real Standard Notes account:

- `sn session --add` — `Response status: 200 OK`, cookie-based tokens persisted.
- `sn stats`, `sn get notes`, `sn get tags`, `sn search` — round-trip cleanly.
- `sn add note --title ... --tag ...` + `sn get notes` returns the decrypted content + tag association.
- `sn delete note`, `sn delete tag` — clean removal.

## Commands run

- `make lint` — same 222 pre-existing issues as `origin/master`; **zero new issues** introduced. Verified by diffing per-file lint output between branch and master (only line-number shifts on existing warnings).
- `make test` — passes on `common`, `auth`, `session`, `crypto`, `cache`, `schemas`, `log`. The `items` package's `TestMain` requires live SN credentials and fails the same way on `origin/master` — this PR doesn't touch that test plumbing.
- `go build ./...` — clean.

## Security implications

- No new credentials or secrets handled.
- No changes to crypto, key derivation, or session-lifecycle code.
- The new headers identify the client to the API; they don't change authentication semantics. The values are static strings, not user-derived.
- Behavior change: requests that previously reached the API and were rejected now reach the auth/sync services. No path where this PR makes a previously-successful request fail.

## Disclosure

This patch was developed with Claude Code (Anthropic's CLI), under human review and verification.