### PR TITLE
Mark test credentials for GitGuardian and drop a live fallback credential

### DIFF
--- a/auth/authentication_test.go
+++ b/auth/authentication_test.go
@@ -31,7 +31,7 @@ var (
 func localTestMain() {
 	localServer := "http://ramea:3000"
 	testUserEmail = fmt.Sprintf("ramea-%s", strconv.FormatInt(time.Now().UnixNano(), 16))
-	testUserPassword = "secretsanta"
+	testUserPassword = "secretsanta" // ggignore
 
 	rInput := RegisterInput{
 		Client:    retryablehttp.NewClient(),
@@ -199,7 +199,7 @@ func TestRegistrationWithInvalidShortPassword(t *testing.T) {
 func TestRegistrationAndSignInWithNewCredentials(t *testing.T) {
 	if strings.Contains(os.Getenv(common.EnvServer), "ramea") {
 		emailAddr := testEmailAddr
-		password := "secretsanta"
+		password := "secretsanta" // ggignore
 
 		rInput := RegisterInput{
 			Password:  password,

--- a/cache/consecutive_sync_isolated_test.go
+++ b/cache/consecutive_sync_isolated_test.go
@@ -29,20 +29,8 @@ func TestConsecutiveCacheSyncIsolated(t *testing.T) {
 		}
 	}()
 
-	// Get credentials from environment or use defaults
-	email := os.Getenv(common.EnvEmail)
-	password := os.Getenv(common.EnvPassword)
-	server := os.Getenv(common.EnvServer)
-
-	if email == "" || password == "" {
-		// Use default test credentials if environment variables not set
-		email = "gosn-v2-20250605@lessknown.co.uk"
-		password = "gosn-v2-20250605@lessknown.co.uk"
-	}
-
-	if server == "" {
-		server = "https://api.standardnotes.com"
-	}
+	// Get credentials from the environment, skipping if they are not configured
+	email, password, server := testCredentials(t)
 
 	t.Logf("Testing consecutive sync with server: %s, email: %s", server, email)
 

--- a/cache/consecutive_sync_test.go
+++ b/cache/consecutive_sync_test.go
@@ -11,22 +11,33 @@ import (
 	"github.com/jonhadfield/gosn-v2/session"
 )
 
-// getRealTestSession creates a test session with real Standard Notes backend
-func getRealTestSession(dbPath string) (*Session, error) {
-	// Use the same environment variables as the main cache tests
-	email := os.Getenv(common.EnvEmail)
-	password := os.Getenv(common.EnvPassword)
-	server := os.Getenv(common.EnvServer)
+// testCredentials returns the credentials used by tests that talk to a real
+// Standard Notes backend, skipping the caller when they are not configured.
+func testCredentials(tb testing.TB) (email, password, server string) {
+	tb.Helper()
+
+	email = os.Getenv(common.EnvEmail)
+	password = os.Getenv(common.EnvPassword)
+	server = os.Getenv(common.EnvServer)
 
 	if email == "" || password == "" {
-		// Use default test credentials if environment variables not set
-		email = "gosn-v2-20250605@lessknown.co.uk"
-		password = "gosn-v2-20250605@lessknown.co.uk"
+		tb.Skipf("skipping test that requires server authentication (%s and %s must be set)",
+			common.EnvEmail, common.EnvPassword)
 	}
 
 	if server == "" {
-		server = "https://api.standardnotes.com"
+		server = common.APIServer
 	}
+
+	return email, password, server
+}
+
+// getRealTestSession creates a test session with real Standard Notes backend
+func getRealTestSession(tb testing.TB, dbPath string) (*Session, error) {
+	tb.Helper()
+
+	// Use the same environment variables as the main cache tests
+	email, password, server := testCredentials(tb)
 
 	// Sign in to get a real session
 	gs, err := auth.CliSignIn(email, password, server, true)
@@ -71,7 +82,7 @@ func TestConsecutiveCacheSync(t *testing.T) {
 	dbPath := filepath.Join(tempDir, "test_consecutive.db")
 
 	// Get real session from testSetup (same as other cache tests)
-	testSession, err := getRealTestSession(dbPath)
+	testSession, err := getRealTestSession(t, dbPath)
 	if err != nil {
 		t.Fatalf("Failed to get real test session: %v", err)
 	}
@@ -346,7 +357,7 @@ func BenchmarkConsecutiveSync(b *testing.B) {
 
 	dbPath := filepath.Join(tempDir, "bench_consecutive.db")
 
-	testSession, err := getRealTestSession(dbPath)
+	testSession, err := getRealTestSession(b, dbPath)
 	if err != nil {
 		b.Fatalf("Failed to get real test session: %v", err)
 	}

--- a/claudedocs/gitguardian-exclusions.md
+++ b/claudedocs/gitguardian-exclusions.md
@@ -1,0 +1,98 @@
+# GitGuardian exclusion plan
+
+Three layers, applied at different points. Layer 1 is committed to this repo;
+layer 2 has to be entered in the GitGuardian dashboard by hand; layer 3 is
+optional and only affects local/CI runs of `ggshield`.
+
+## Layer 1 — inline `// ggignore` tags (done, in-repo)
+
+Tagged lines carrying test key material or fixture passwords:
+
+| File | Lines | What |
+|---|---|---|
+| `auth/authentication_test.go` | 34, 202 | `"secretsanta"` fixture password |
+| `items/gosn_test.go` | 37 | `"secretsanta"` fixture password |
+| `crypto/encryption_test.go` | 26, 28, 31, 32, 169, 176, 180 | derived master key, server password, raw AES keys |
+| `items/items_test.go` | 1384, 1390, 1410, 1416, 1429 | items keys and item keys |
+| `session/parse_test.go` | 10, 15 | serialised session string, master key |
+
+Deliberately **not** tagged: `nonce` and `authData` locals. A nonce ships in the
+clear alongside its ciphertext and `authData` is base64 JSON of public key
+params, so neither is credential material. Tagging them also makes gofmt align
+the trailing comment against the 300-character `authData` line, which is
+unreadable. If GitGuardian does raise them, the layer-2 path exclusions cover it.
+
+## Layer 2 — workspace exclusion rules (paste into the dashboard)
+
+Settings -> Secrets detection -> Exclusions. Scope each of these to the
+`jonhadfield/gosn-v2` repository rather than the whole workspace. These apply
+retroactively, so existing incidents drop off the table once saved.
+
+### Filepath exclusions
+
+```
+**/*_test.go
+test.json
+testuser-encrypted-backup.txt
+claudedocs/**
+**/*_TEST_RESULTS.md
+**/*_ANALYSIS.md
+```
+
+Notes on the non-obvious entries:
+
+- `test.json` and `testuser-encrypted-backup.txt` sit at the repo root and match
+  no `*test*` directory glob, so they need naming outright. Both hold real
+  004-format encrypted payloads for a throwaway account.
+- `claudedocs/**` covers five analysis write-ups that quote master keys and
+  session strings inline: `credential_test_results.md`,
+  `authentication_analysis.md`, `authentication_fix_complete.md`,
+  `authentication_investigation_summary.md`, `auth_request_comparison.md`.
+
+### Secret pattern exclusions (regex)
+
+```
+^004:[0-9a-f]{48}:
+^ramea-[0-9a-f]+$
+```
+
+The first matches the Standard Notes 004 ciphertext prefix, which is what makes
+the encrypted fixtures look like key material. The second matches the generated
+local-test usernames.
+
+## Layer 3 — `.gitguardian.yaml` (optional, CLI only)
+
+Only worth adding if you start running `ggshield` in pre-commit or CI. It will
+**not** clear dashboard incidents — GitGuardian's docs are explicit that
+"ggshield does not share its ignored secrets with the dashboard".
+
+```yaml
+version: 2
+secret:
+  ignored_paths:
+    - '**/*_test.go'
+    - 'test.json'
+    - 'testuser-encrypted-backup.txt'
+    - 'claudedocs/**'
+```
+
+## Live credential — removed rather than suppressed
+
+`cache/consecutive_sync_test.go` and `cache/consecutive_sync_isolated_test.go`
+used to hardcode a fallback for a live account on lessknown.co.uk when
+`SN_EMAIL` / `SN_PASSWORD` were unset. That was a real credential, not a
+fixture, so it was deleted rather than tagged or excluded.
+
+Both files now go through a shared helper in `cache/consecutive_sync_test.go`:
+
+```go
+func testCredentials(tb testing.TB) (email, password, server string)
+```
+
+It reads `SN_EMAIL`, `SN_PASSWORD` and `SN_SERVER`, calls `tb.Skipf` when the
+first two are unset, and defaults the server to `common.APIServer`. `tb.Helper()`
+means the skip is reported at the caller's line. Taking `testing.TB` lets both
+`TestConsecutiveCacheSync` and `BenchmarkConsecutiveSync` share it.
+
+The account itself should still be considered exposed — it was in git history
+before this change, so rotate or delete it regardless.

--- a/crypto/encryption_test.go
+++ b/crypto/encryption_test.go
@@ -23,13 +23,13 @@ func TestGenerateEncryptedPasswordWithValidInput004(t *testing.T) {
 	t.Parallel()
 
 	var testInput GenerateEncryptedPasswordInput
-	testInput.UserPassword = "debugtest"
+	testInput.UserPassword = "debugtest" // ggignore
 	testInput.Identifier = "sn004@lessknown.co.uk"
-	testInput.PasswordNonce = "2c409996650e46c748856fbd6aa549f89f35be055a8f9bfacdf0c4b29b2152e9"
+	testInput.PasswordNonce = "2c409996650e46c748856fbd6aa549f89f35be055a8f9bfacdf0c4b29b2152e9" // ggignore
 	masterKey, serverPassword, err := GenerateMasterKeyAndServerPassword004(testInput)
 	require.NoError(t, err)
-	require.Equal(t, "2396d6ac0bc70fe45db1d2bcf3daa522603e9c6fcc88dc933ce1a3a31bbc08ed", masterKey)
-	require.Equal(t, "a5eb9fbc767eafd6e54fd9d3646b19520e038ba2ccc9cceddf2340b37b788b47", serverPassword)
+	require.Equal(t, "2396d6ac0bc70fe45db1d2bcf3daa522603e9c6fcc88dc933ce1a3a31bbc08ed", masterKey)      // ggignore
+	require.Equal(t, "a5eb9fbc767eafd6e54fd9d3646b19520e038ba2ccc9cceddf2340b37b788b47", serverPassword) // ggignore
 }
 
 //
@@ -166,18 +166,18 @@ func TestGenerateEncryptedPasswordWithValidInput004(t *testing.T) {
 // }
 
 func TestDecryptString(t *testing.T) {
-	rawKey := "e73faf921cc265b7a001451d8760a6a6e2270d0dbf1668f9971fd75c8018ffd4"
+	rawKey := "e73faf921cc265b7a001451d8760a6a6e2270d0dbf1668f9971fd75c8018ffd4" // ggignore
 	cipherText := "kRd2w+7FQBIXaNGze7G28GOIUSngrqtx/t5Jus76z3z+eM18GkJT7Lc/ZpqJiH9I6fdksNdo6uvfip8TCIT458XxcrqIP24Bxk9xaz2Q9IQ="
 	nonce := "d211fc5dee400fe54ca04ac43ecac512c9d0dabb6c4ee0f3"
 	authData := "eyJrcCI6eyJpZGVudGlmaWVyIjoiZ29zbi12MkBsZXNza25vd24uY28udWsiLCJwd19ub25jZSI6ImIzYjc3Yzc5YzlmZWE5ODY3MWU2NmFmNDczMzZhODhlNWE1MTUyMjI4YjEwMTQ2NDEwM2M1MjJiMWUzYWU0ZGEiLCJ2ZXJzaW9uIjoiMDA0Iiwib3JpZ2luYXRpb24iOiJyZWdpc3RyYXRpb24iLCJjcmVhdGVkIjoiMTYwODEzNDk0NjY5MiJ9LCJ1IjoiNjI3YTg4YTAtY2NkNi00YTY4LWFjZWUtYjM0ODQ5NDZmMjY1IiwidiI6IjAwNCJ9"
 	plainText, err := DecryptCipherText(cipherText, rawKey, nonce, authData)
 
 	require.NoError(t, err)
-	require.Equal(t, "9381f4ac4371cd9e31c3389442897d5c7de3da3d787927709ab601e28767d18a", string(plainText))
+	require.Equal(t, "9381f4ac4371cd9e31c3389442897d5c7de3da3d787927709ab601e28767d18a", string(plainText)) // ggignore
 }
 
 func TestEncryptDecryptString(t *testing.T) {
-	rawKey := "b396412f690bfb40801c764af7975bc019f3de79b1ed24385e98787aff81c003"
+	rawKey := "b396412f690bfb40801c764af7975bc019f3de79b1ed24385e98787aff81c003" // ggignore
 	tempExpectedCipherText := "B+8vUwmSTGZCba6mU2gMSMl55fpt38Wv/yWxAF4pEveX0sjqSYgjT5PA8/yy7LKotF+kjmuiHNvYtH7hB7BaqJrG8Q4G5Sj15tIu8PtlWECJWHnPxHkeiJW1MiS1ypR0t3y+Uc7cRpGPwnQIqJDr/Yl1vp2tZXlaSy0zYtGYlw5GwUnLxXtQBQC1Ml3rzZDpaIT9zIr9Qluv7Q7JXOJ7rAbj95MtsV2CJD4RwjhhJ11fpI3N8+uXqp4="
 
 	nonce := "6045eaf9774a877203b68bb12159f9c5c0c3d19df4949e40"

--- a/items/gosn_test.go
+++ b/items/gosn_test.go
@@ -24,7 +24,7 @@ var (
 func localTestMain() {
 	localServer := "http://ramea:3000"
 	testUserEmail = fmt.Sprintf("ramea-%s", strconv.FormatInt(time.Now().UnixNano(), 16))
-	testUserPassword = "secretsanta"
+	testUserPassword = "secretsanta" // ggignore
 
 	rInput := auth.RegisterInput{
 		Password:  testUserPassword,

--- a/items/items_test.go
+++ b/items/items_test.go
@@ -1365,13 +1365,13 @@ func genNotes(num int, textParas int) (notes Items) {
 
 func TestDecryptNoteText(t *testing.T) {
 	// decrypt encrypted items key
-	decryptedItemsKey := "366df581a789de771a1613d7d0289bbaff7bf4249a7dd15e458a12c361cb7b73"
+	decryptedItemsKey := "366df581a789de771a1613d7d0289bbaff7bf4249a7dd15e458a12c361cb7b73" // ggignore
 	cipherText := "sJhGyLDN4x/wXBcE6TWCsZMaAPfK04ojpsYzjI/zEGvkBsRPGPyihTyQGHvAqcHMWOIZZYZDC2+8YlxVdreF2LblOM8hXz3hwtFDE3DcN5g="
 	nonce := "b55df872abe8c97f82bb875a14a9b344584825edef1d0ed7"
 	authData := "eyJ1IjoiYmE5MjQ4YWMtOWUxNC00ODcyLTgxNjYtNTkzMjg5ZDg5ODYwIiwidiI6IjAwNCJ9"
 	contentItemKeyHexBytes, err := crypto.DecryptCipherText(cipherText, decryptedItemsKey, nonce, authData)
 	require.NoError(t, err)
-	require.Equal(t, "b396412f690bfb40801c764af7975bc019f3de79b1ed24385e98787aff81c003", string(contentItemKeyHexBytes))
+	require.Equal(t, "b396412f690bfb40801c764af7975bc019f3de79b1ed24385e98787aff81c003", string(contentItemKeyHexBytes)) // ggignore
 
 	rawKey := string(contentItemKeyHexBytes)
 	nonce = "6045eaf9774a877203b68bb12159f9c5c0c3d19df4949e40"
@@ -1390,13 +1390,13 @@ func TestDecryptNoteText(t *testing.T) {
 
 func TestDecryptItemKey(t *testing.T) {
 	// decrypt encrypted item key
-	rawKey := "e73faf921cc265b7a001451d8760a6a6e2270d0dbf1668f9971fd75c8018ffd4"
+	rawKey := "e73faf921cc265b7a001451d8760a6a6e2270d0dbf1668f9971fd75c8018ffd4" // ggignore
 	cipherText := "kRd2w+7FQBIXaNGze7G28GOIUSngrqtx/t5Jus76z3z+eM18GkJT7Lc/ZpqJiH9I6fdksNdo6uvfip8TCIT458XxcrqIP24Bxk9xaz2Q9IQ="
 	nonce := "d211fc5dee400fe54ca04ac43ecac512c9d0dabb6c4ee0f3"
 	authData := "eyJrcCI6eyJpZGVudGlmaWVyIjoiZ29zbi12MkBsZXNza25vd24uY28udWsiLCJwd19ub25jZSI6ImIzYjc3Yzc5YzlmZWE5ODY3MWU2NmFmNDczMzZhODhlNWE1MTUyMjI4YjEwMTQ2NDEwM2M1MjJiMWUzYWU0ZGEiLCJ2ZXJzaW9uIjoiMDA0Iiwib3JpZ2luYXRpb24iOiJyZWdpc3RyYXRpb24iLCJjcmVhdGVkIjoiMTYwODEzNDk0NjY5MiJ9LCJ1IjoiNjI3YTg4YTAtY2NkNi00YTY4LWFjZWUtYjM0ODQ5NDZmMjY1IiwidiI6IjAwNCJ9"
 	contentItemKeyHexBytes, err := crypto.DecryptCipherText(cipherText, rawKey, nonce, authData)
 	require.NoError(t, err)
-	require.Equal(t, "9381f4ac4371cd9e31c3389442897d5c7de3da3d787927709ab601e28767d18a", string(contentItemKeyHexBytes))
+	require.Equal(t, "9381f4ac4371cd9e31c3389442897d5c7de3da3d787927709ab601e28767d18a", string(contentItemKeyHexBytes)) // ggignore
 
 	// decrypt item key content with item key
 	rawKey = string(contentItemKeyHexBytes)
@@ -1409,7 +1409,7 @@ func TestDecryptItemKey(t *testing.T) {
 	var ik ItemsKey
 	err = json.Unmarshal(dIKeyContent, &ik)
 	require.NoError(t, err)
-	require.Equal(t, "366df581a789de771a1613d7d0289bbaff7bf4249a7dd15e458a12c361cb7b73", ik.ItemsKey)
+	require.Equal(t, "366df581a789de771a1613d7d0289bbaff7bf4249a7dd15e458a12c361cb7b73", ik.ItemsKey) // ggignore
 }
 
 // func TestRegisterExportImport(t *testing.T) {

--- a/session/parse_test.go
+++ b/session/parse_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestParseSessionStringValid(t *testing.T) {
-	sessionString := "{\"Server\":\"http://ramea:3000\",\"Token\":\"\",\"MasterKey\":\"5319f9c148ee3dbe78fc149e8643775242d7e83216060ee5e228ab2ec3d88a76\",\"keyParams\":{\"created\":\"1608473387799\",\"identifier\":\"test-user\",\"origination\":\"registration\",\"pw_nonce\":\"yJTyMmLr3KqOc7ifRfe1H7Pu8591n7Sj\",\"version\":\"004\"},\"access_token\":\"1:3dc699a1-451d-4de3-b01d-fca32554292b:Io9MOsc.WDIq0JBt\",\"refresh_token\":\"1:3dc699a1-451d-4de3-b01d-fca32554292b:-ixQV.-RMCCSPG0M\",\"access_expiration\":1648647400000,\"refresh_expiration\":1675020326000,\"SchemaValidation\":false}"
+	sessionString := "{\"Server\":\"http://ramea:3000\",\"Token\":\"\",\"MasterKey\":\"5319f9c148ee3dbe78fc149e8643775242d7e83216060ee5e228ab2ec3d88a76\",\"keyParams\":{\"created\":\"1608473387799\",\"identifier\":\"test-user\",\"origination\":\"registration\",\"pw_nonce\":\"yJTyMmLr3KqOc7ifRfe1H7Pu8591n7Sj\",\"version\":\"004\"},\"access_token\":\"1:3dc699a1-451d-4de3-b01d-fca32554292b:Io9MOsc.WDIq0JBt\",\"refresh_token\":\"1:3dc699a1-451d-4de3-b01d-fca32554292b:-ixQV.-RMCCSPG0M\",\"access_expiration\":1648647400000,\"refresh_expiration\":1675020326000,\"SchemaValidation\":false}" // ggignore
 
 	sess, err := ParseSessionString(sessionString)
 	require.NoError(t, err)
 	require.Equal(t, "http://ramea:3000", sess.Server)
-	require.Equal(t, "5319f9c148ee3dbe78fc149e8643775242d7e83216060ee5e228ab2ec3d88a76", sess.MasterKey)
+	require.Equal(t, "5319f9c148ee3dbe78fc149e8643775242d7e83216060ee5e228ab2ec3d88a76", sess.MasterKey) // ggignore
 	require.Equal(t, int64(1648647400000), sess.AccessExpiration)
 }
 


### PR DESCRIPTION
Stops GitGuardian raising the repo's test fixtures as credential leaks, and removes one credential it was right about.

## Inline `// ggignore` tags

Seventeen lines carrying test key material or fixture passwords are tagged with an inline `// ggignore` comment. This is an engine-side tag, so it applies to dashboard scanning rather than only to local `ggshield` runs — GitGuardian uses it in their own repo's test fixtures.

| File | Lines | What |
|---|---|---|
| `auth/authentication_test.go` | 34, 202 | `"secretsanta"` fixture password |
| `items/gosn_test.go` | 37 | `"secretsanta"` fixture password |
| `crypto/encryption_test.go` | 26, 28, 31, 32, 169, 176, 180 | derived master key, server password, raw AES keys |
| `items/items_test.go` | 1384, 1390, 1410, 1416, 1429 | items keys and item keys |
| `session/parse_test.go` | 10, 15 | serialised session string, master key |

`nonce` and `authData` locals are deliberately left untagged. A nonce ships in the clear alongside its ciphertext and `authData` is base64 JSON of public key params, so neither is credential material — and tagging them makes gofmt align the trailing comment against a 300-character line.

## Live credential removed rather than suppressed

`cache/consecutive_sync_test.go` and `cache/consecutive_sync_isolated_test.go` hardcoded a fallback for a live Standard Notes account when `SN_EMAIL` / `SN_PASSWORD` were unset. That was a real credential, not a fixture, so it is deleted rather than tagged.

Both files now share one helper:

```go
func testCredentials(tb testing.TB) (email, password, server string)
```

It reads `SN_EMAIL`, `SN_PASSWORD` and `SN_SERVER`, calls `tb.Skipf` when the first two are unset, and defaults the server to `common.APIServer`. `tb.Helper()` reports the skip at the caller's line. Taking `testing.TB` lets `TestConsecutiveCacheSync` and `BenchmarkConsecutiveSync` share it.

The account itself has since been deleted from Standard Notes, and the stale `SN_EMAIL` / `SN_PASSWORD` repo secrets removed.

## Exclusion plan

`claudedocs/gitguardian-exclusions.md` documents the dashboard rules needed for fixtures no inline tag can reach — the encrypted payloads at the repo root, and the analysis write-ups that quote master keys inline. Those still need entering in the GitGuardian workspace settings; they are not applied by merging this.

## Testing

`SN_SKIP_SESSION_TESTS=true go test ./...` passes on every package except `items`, and both skip paths in the new helper were exercised separately.

Note that `go test ./items/` fails on this branch with `username cannot be empty`. That is pre-existing on master — reproducible on a clean `master` checkout — and is fixed by the branch in #83, not by anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLbow7VZF5fqwNBbKVnZqv
