### PR TITLE
Bump actions/checkout and actions/setup-go to v7

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25.1'
       -


### PR DESCRIPTION
Clears the Node 20 deprecation warning appearing on every workflow run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4, actions/setup-go@v4
```

## Versions

Checked what each tag actually declares in its `action.yml`:

| Action | Tag | `runs.using` |
|---|---|---|
| actions/checkout | v4 | node20 |
| actions/checkout | **v7** | **node24** |
| actions/setup-go | v4 | node16 |
| actions/setup-go | v5 | node20 |
| actions/setup-go | v6 | node24 |
| actions/setup-go | **v7** | **node24** |

Worth noting that bumping to v5 would not have fixed this: `actions/setup-go@v5` still declares node20, so the warning would have persisted for that action. v6 is the first release that moves. v7 is the current major for both.

`actions/setup-go@v4` was on node16, older than the warning implied.

## Compatibility

Both actions are used with stable inputs only — `fetch-depth` for checkout, `go-version` for setup-go — so no input changes are required by the major bump.

`github/codeql-action` and `codacy/codacy-coverage-reporter-action` are composite actions with no Node runtime, so they are unaffected and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLbow7VZF5fqwNBbKVnZqv
