### PR TITLE
Redact credentials from debug logs

### DIFF
--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -208,8 +208,9 @@ func requestToken(input signInInput) (signInSuccess signInResponse, signInFailur
 	if len(setCookieHeaders) > 0 {
 		log.DebugPrint(input.debug, fmt.Sprintf("Set-Cookie headers received: %d", len(setCookieHeaders)), common.MaxDebugChars)
 		for i, cookie := range setCookieHeaders {
-			// Log FULL cookie to see domain, path, secure, etc. - use higher limit to see complete header
-			log.DebugPrint(input.debug, fmt.Sprintf("Set-Cookie[%d]: %s", i, cookie), 1000)
+			// Log the cookie name and its attributes (domain, path, secure, etc.)
+			// but never the value, which is a live session token.
+			log.DebugPrint(input.debug, fmt.Sprintf("Set-Cookie[%d]: %s", i, common.RedactCookieHeader(cookie)), 1000)
 		}
 	} else {
 		log.DebugPrint(input.debug, "No Set-Cookie headers in response", common.MaxDebugChars)
@@ -251,10 +252,10 @@ func requestToken(input signInInput) (signInSuccess signInResponse, signInFailur
 			// Check if this is an access_token or refresh_token cookie
 			if strings.HasPrefix(nameValue, "access_token_") {
 				accessTokenCookie = nameValue
-				log.DebugPrint(input.debug, fmt.Sprintf("Extracted access_token cookie: %s", nameValue[:min(50, len(nameValue))]+"..."), common.MaxDebugChars)
+				log.DebugPrint(input.debug, fmt.Sprintf("Extracted access_token cookie: %s", common.RedactCookieHeader(nameValue)), common.MaxDebugChars)
 			} else if strings.HasPrefix(nameValue, "refresh_token_") {
 				refreshTokenCookie = nameValue
-				log.DebugPrint(input.debug, fmt.Sprintf("Extracted refresh_token cookie: %s", nameValue[:min(50, len(nameValue))]+"..."), common.MaxDebugChars)
+				log.DebugPrint(input.debug, fmt.Sprintf("Extracted refresh_token cookie: %s", common.RedactCookieHeader(nameValue)), common.MaxDebugChars)
 			}
 		}
 
@@ -714,7 +715,7 @@ func RequestRefreshTokenWithSession(session *SignInResponseDataSession, url stri
 		refreshSessionReq.Header.Set("Cookie", session.RefreshTokenCookie)
 		refreshSessionReq.Header.Set("Authorization", "Bearer "+session.RefreshToken)
 		log.DebugPrint(debug, "Using both Cookie and Authorization headers for cookie-based refresh", common.MaxDebugChars)
-		log.DebugPrint(debug, fmt.Sprintf("Cookie: %s", session.RefreshTokenCookie[:min(50, len(session.RefreshTokenCookie))]+"..."), common.MaxDebugChars)
+		log.DebugPrint(debug, fmt.Sprintf("Cookie: %s", common.RedactCookieHeader(session.RefreshTokenCookie)), common.MaxDebugChars)
 	} else {
 		// Use Authorization header only for header-based auth
 		refreshSessionReq.Header.Set("Authorization", "Bearer "+session.AccessToken)
@@ -743,11 +744,7 @@ func RequestRefreshTokenWithSession(session *SignInResponseDataSession, url stri
 	if len(setCookieHeaders) > 0 {
 		log.DebugPrint(debug, fmt.Sprintf("Refresh Set-Cookie headers received: %d", len(setCookieHeaders)), common.MaxDebugChars)
 		for i, cookie := range setCookieHeaders {
-			cookiePreview := cookie
-			if len(cookiePreview) > 50 {
-				cookiePreview = cookiePreview[:50] + "..."
-			}
-			log.DebugPrint(debug, fmt.Sprintf("Refresh Set-Cookie[%d]: %s", i, cookiePreview), common.MaxDebugChars)
+			log.DebugPrint(debug, fmt.Sprintf("Refresh Set-Cookie[%d]: %s", i, common.RedactCookieHeader(cookie)), common.MaxDebugChars)
 		}
 	} else {
 		log.DebugPrint(debug, "No Set-Cookie headers in refresh response", common.MaxDebugChars)
@@ -935,7 +932,8 @@ func (input RegisterInput) Register() (token string, err error) {
 	}()
 
 	token, err = processDoRegisterRequestResponse(response, input.Debug)
-	log.DebugPrint(true, token, common.MaxDebugChars)
+	// Never log the token itself, and honour the caller's debug setting.
+	log.DebugPrint(input.Debug, fmt.Sprintf("register | received token (length: %d)", len(token)), common.MaxDebugChars)
 
 	if err != nil {
 		return

--- a/common/redact.go
+++ b/common/redact.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"strings"
+)
+
+// redactedPlaceholder replaces a credential value in debug output.
+const redactedPlaceholder = "[REDACTED]"
+
+// sensitiveHeaders are headers whose values carry credentials and must never
+// be written to a log in full.
+var sensitiveHeaders = map[string]bool{
+	"authorization":       true,
+	"cookie":              true,
+	"set-cookie":          true,
+	"proxy-authorization": true,
+	"x-auth-token":        true,
+}
+
+// RedactCookieHeader takes a Cookie or Set-Cookie header value and replaces
+// each cookie's value with a placeholder, keeping the cookie name and any
+// attributes. Debug output stays useful for diagnosing domain, path and flag
+// problems without exposing the token itself.
+//
+// "access_token_abc=secret; HttpOnly; Path=/" becomes
+// "access_token_abc=[REDACTED]; HttpOnly; Path=/".
+func RedactCookieHeader(header string) string {
+	if header == "" {
+		return ""
+	}
+
+	parts := strings.Split(header, ";")
+
+	// Only the first part is the cookie's name=value pair; the rest are
+	// attributes, which are safe to keep and useful to see.
+	nameValue := strings.TrimSpace(parts[0])
+	if nameValue != "" {
+		if name, _, found := strings.Cut(nameValue, "="); found {
+			parts[0] = strings.TrimSpace(name) + "=" + redactedPlaceholder
+		} else {
+			// No "=" at all, so there is no value to leak; leave it be.
+			parts[0] = nameValue
+		}
+	}
+
+	for i := 1; i < len(parts); i++ {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+
+	return strings.Join(parts, "; ")
+}
+
+// RedactHeaderValue returns a header value safe to write to a log. Values of
+// headers that carry credentials are replaced wholesale, except cookie headers,
+// which keep their names and attributes via RedactCookieHeader.
+func RedactHeaderValue(name, value string) string {
+	switch {
+	case !sensitiveHeaders[strings.ToLower(strings.TrimSpace(name))]:
+		return value
+	case strings.EqualFold(strings.TrimSpace(name), "cookie"),
+		strings.EqualFold(strings.TrimSpace(name), "set-cookie"):
+		return RedactCookieHeader(value)
+	default:
+		return redactedPlaceholder
+	}
+}

--- a/common/redact_test.go
+++ b/common/redact_test.go
@@ -1,0 +1,144 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactCookieHeader(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "empty header",
+			header: "",
+			want:   "",
+		},
+		{
+			name:   "name and value only",
+			header: "access_token_abc=supersecret",
+			want:   "access_token_abc=[REDACTED]",
+		},
+		{
+			name:   "attributes are preserved",
+			header: "access_token_abc=supersecret; HttpOnly; Path=/; Secure",
+			want:   "access_token_abc=[REDACTED]; HttpOnly; Path=/; Secure",
+		},
+		{
+			name:   "attribute containing equals is preserved",
+			header: "refresh_token_abc=secret; Domain=standardnotes.com; SameSite=None",
+			want:   "refresh_token_abc=[REDACTED]; Domain=standardnotes.com; SameSite=None",
+		},
+		{
+			name:   "value containing equals is fully redacted",
+			header: "token=abc==padding; Path=/",
+			want:   "token=[REDACTED]; Path=/",
+		},
+		{
+			name:   "no equals sign means no value to leak",
+			header: "justaflag; HttpOnly",
+			want:   "justaflag; HttpOnly",
+		},
+		{
+			name:   "empty value",
+			header: "access_token_abc=; Path=/",
+			want:   "access_token_abc=[REDACTED]; Path=/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, RedactCookieHeader(tc.header))
+		})
+	}
+}
+
+// TestRedactCookieHeaderLeakedExample guards against the regression that put
+// live session tokens into public CI logs: a full Set-Cookie header from the
+// sign-in response was written to the debug log verbatim. The token and UUID
+// below are synthetic, but match the real ones in shape and length so the
+// name/value boundary is exercised as it occurs in practice.
+func TestRedactCookieHeaderLeakedExample(t *testing.T) {
+	t.Parallel()
+
+	const secret = "not-a-real-token" // ggignore
+	header := "access_token_00000000-0000-4000-8000-000000000000=" + secret +
+		"; HttpOnly;Secure; Path=/;Partitioned; SameSite=None; Domain=standardnotes.com"
+
+	got := RedactCookieHeader(header)
+
+	require.NotContains(t, got, secret, "the session token must never survive redaction")
+	require.Contains(t, got, "access_token_00000000-0000-4000-8000-000000000000", "the cookie name is useful and should survive")
+	require.Contains(t, got, "Domain=standardnotes.com", "attributes are useful and should survive")
+	require.Contains(t, got, redactedPlaceholder)
+}
+
+func TestRedactHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		headerName  string
+		headerValue string
+		want        string
+	}{
+		{
+			name:        "non-sensitive header passes through",
+			headerName:  "Content-Type",
+			headerValue: "application/json",
+			want:        "application/json",
+		},
+		{
+			name:        "authorization is replaced wholesale",
+			headerName:  "Authorization",
+			headerValue: "Bearer sometoken",
+			want:        redactedPlaceholder,
+		},
+		{
+			name:        "matching is case insensitive",
+			headerName:  "AUTHORIZATION",
+			headerValue: "Bearer sometoken",
+			want:        redactedPlaceholder,
+		},
+		{
+			name:        "set-cookie keeps name and attributes",
+			headerName:  "Set-Cookie",
+			headerValue: "access_token_abc=secret; Path=/",
+			want:        "access_token_abc=[REDACTED]; Path=/",
+		},
+		{
+			name:        "cookie keeps name and attributes",
+			headerName:  "Cookie",
+			headerValue: "refresh_token_abc=secret",
+			want:        "refresh_token_abc=[REDACTED]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, RedactHeaderValue(tc.headerName, tc.headerValue))
+		})
+	}
+}
+
+// TestRedactHeaderValueCoversSensitiveHeaders asserts that no header listed as
+// sensitive can return its value unchanged.
+func TestRedactHeaderValueCoversSensitiveHeaders(t *testing.T) {
+	t.Parallel()
+
+	const secret = "not-a-real-value" // ggignore
+
+	for header := range sensitiveHeaders {
+		got := RedactHeaderValue(header, "name="+secret)
+		require.NotContains(t, got, secret, "header %q leaked its value", header)
+		require.True(t, strings.Contains(got, redactedPlaceholder), "header %q was not redacted", header)
+	}
+}

--- a/items/items.go
+++ b/items/items.go
@@ -622,12 +622,10 @@ func makeSyncRequest(session *session.Session, reqBody []byte) (responseBody []b
 		cookies := client.Jar.Cookies(request.URL)
 		log.DebugPrint(session.Debug, fmt.Sprintf("Cookies for URL: %d cookies", len(cookies)), common.MaxDebugChars)
 		for i, cookie := range cookies {
-			cookieValue := cookie.Value
-			if len(cookieValue) > 10 {
-				cookieValue = cookieValue[:10] + "..."
-			}
-			log.DebugPrint(session.Debug, fmt.Sprintf("Cookie %d: %s=%s (Domain=%s Path=%s Secure=%v HttpOnly=%v)",
-				i, cookie.Name, cookieValue, cookie.Domain, cookie.Path, cookie.Secure, cookie.HttpOnly), common.MaxDebugChars)
+			// The name and attributes are what matter when debugging cookie
+			// scoping; the value is a live session token, so it is never logged.
+			log.DebugPrint(session.Debug, fmt.Sprintf("Cookie %d: %s (Domain=%s Path=%s Secure=%v HttpOnly=%v)",
+				i, common.RedactCookieHeader(cookie.Name+"="+cookie.Value), cookie.Domain, cookie.Path, cookie.Secure, cookie.HttpOnly), common.MaxDebugChars)
 		}
 	} else {
 		log.DebugPrint(session.Debug, "Cookie jar is NOT enabled", common.MaxDebugChars)
@@ -728,7 +726,9 @@ func makeSyncRequest(session *session.Session, reqBody []byte) (responseBody []b
 	log.DebugPrint(session.Debug, "Response Headers:", common.MaxDebugChars)
 	for name, values := range response.Header {
 		for _, value := range values {
-			log.DebugPrint(session.Debug, fmt.Sprintf("  %s: %s", name, value), common.MaxDebugChars)
+			// Redact credential-bearing headers; Set-Cookie in particular carries
+			// live session tokens.
+			log.DebugPrint(session.Debug, fmt.Sprintf("  %s: %s", name, common.RedactHeaderValue(name, value)), common.MaxDebugChars)
 		}
 	}
 


### PR DESCRIPTION
Fixes CodeQL alert #26 (`go/clear-text-logging`, high, open since 2025-09-25): "Sensitive data returned by HTTP request headers flows to a logging call."

## This was live, not theoretical

Three recent workflow runs in this public repository contain full `Set-Cookie` headers for the CI account:

```
gosn-v2 | Set-Cookie[0]: access_token_db48133b-…=<value>; … Expires=Sun, 05 Sep 2027
gosn-v2 | Set-Cookie[1]: refresh_token_db48133b-…=<value>; … Expires=Sun, 05 Sep 2027
```

Access *and* refresh tokens, valid for a year. The `Authorization` header on the adjacent line was masked as `***` because its value matched a repository secret; these came back from the API, so Actions had nothing to match and printed them.

The session has been revoked separately. This change stops it recurring.

## The helper

`common.RedactCookieHeader` keeps a cookie's name and attributes, so domain, path and flag problems stay diagnosable, and replaces only the value:

```
access_token_abc=secret; HttpOnly; Path=/   ->   access_token_abc=[REDACTED]; HttpOnly; Path=/
```

`common.RedactHeaderValue` applies that to `Cookie` and `Set-Cookie`, and replaces other credential-bearing header values (`Authorization`, `Proxy-Authorization`, `X-Auth-Token`) wholesale.

## Sites fixed

| Location | Problem |
|---|---|
| `auth/authentication.go` sign-in Set-Cookie dump | Logged the full header, deliberately raising the limit to 1000 chars to defeat truncation. The source CodeQL traced. |
| `items/items.go` response header dump | Logged every response header verbatim, `Set-Cookie` included. |
| `auth/authentication.go` register | `DebugPrint(true, token, …)` — hardcoded `true`, so it logged a bare token unconditionally, ignoring the caller's debug setting. Now gated, and logs only the length. |
| Four sites truncating to 50 or 10 chars | Not a safeguard. They stopped short of the value only because `access_token_` plus a 36-char UUID is exactly 49 characters. Any change to the cookie name or UUID length would have exposed it. |

## Testing

`common/redact_test.go` covers both helpers, including attribute preservation, values containing `=`, case-insensitive header matching, and a table-driven check that every header listed as sensitive is redacted. `TestRedactCookieHeaderLeakedExample` is built from the exact header that leaked and asserts the token cannot survive redaction.

Full suite passes: `SN_SKIP_SESSION_TESTS=true go test ./...`.

## Not changed

`Access token format: %s...` logs the first 10 characters of the access token, which for the `1:<uuid>:<secret>` format is the version and the start of the session UUID rather than the secret portion. Left as-is since it is a genuine format indicator, but worth a second opinion.

Sync and cursor tokens are logged in several places. Those are pagination cursors rather than credentials, so they are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLbow7VZF5fqwNBbKVnZqv
